### PR TITLE
Add permissions block to workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 name: Tutorial CI
 on: [ push, pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Restricts GITHUB_TOKEN to read-only contents access, addressing a code scanning alert.