### PR TITLE
Fix transitive dep CVEs via overrides

### DIFF
--- a/ui/extensions/Third-party Detections/package-lock.json
+++ b/ui/extensions/Third-party Detections/package-lock.json
@@ -15,7 +15,7 @@
         "@shoelace-style/shoelace": "^2.20.1",
         "react": "19.2.1",
         "react-dom": "19.2.1",
-        "react-router-dom": "7.6.1"
+        "react-router-dom": "7.13.1"
       },
       "devDependencies": {
         "@babel/core": "7.27.4",
@@ -27,7 +27,7 @@
         "@rollup/plugin-replace": "6.0.2",
         "@web/rollup-plugin-html": "2.3.0",
         "postcss": "^8.5.4",
-        "rollup": "4.41.1",
+        "rollup": "4.59.0",
         "rollup-plugin-postcss": "^4.0.2"
       },
       "engines": {
@@ -49,12 +49,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -63,9 +63,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.3.tgz",
-      "integrity": "sha512-V42wFfx1ymFte+ecf6iXghnnP8kWTO+ZLXIyZq+1LAXHHvTZdVxicn4yiVYdYMGaCO3tmqub11AorKkv+iodqw==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -104,16 +104,16 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.3.tgz",
-      "integrity": "sha512-xnlJYj5zepml8NXtjkG0WquFUv8RskFqyFcVgTBp5k+NaA/8uw/K+OSVf8AMGw5e9HKP2ETd5xpK5MLZQD6b4Q==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.3",
-        "@babel/types": "^7.27.3",
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
       },
       "engines": {
@@ -121,26 +121,26 @@
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.1.tgz",
-      "integrity": "sha512-WnuuDILl9oOBbKnb4L+DyODx7iC47XfzmNCpTttFsSp6hTG7XZxu60+4IO+2/hPfcGOoKbFiwoI/+zwARbNQow==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.1"
+        "@babel/types": "^7.27.3"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
+        "@babel/compat-data": "^7.28.6",
         "@babel/helper-validator-option": "^7.27.1",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
@@ -150,30 +150,40 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
-      "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.27.3"
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -183,9 +193,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -203,9 +213,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -222,27 +232,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.27.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.4.tgz",
-      "integrity": "sha512-Y+bO6U+I7ZKaM5G5rDUZiYfUvQPUibYmAFe7EnKdnKBbVXDZxvp+MWOH5gYciY0EPk4EScsuFMQBbEfpdRKSCQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.27.3"
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.4.tgz",
-      "integrity": "sha512-BRmLHGwpUqLFR2jzx9orBuX/ABDkj2jLKOXrHDTN2aOKL+jFDDKaRNo9nyYsIl9h/UE/7lMKdDjKQQyxKKDZ7g==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.3"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -252,13 +262,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
-      "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -268,9 +278,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-display-name": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.27.1.tgz",
-      "integrity": "sha512-p9+Vl3yuHPmkirRrg021XiP+EETmPMQTLr6Ayjj85RLNEbb3Eya/4VI0vAdzQG9SEAl2Lnt7fy5lZyMzjYoZQQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.28.0.tgz",
+      "integrity": "sha512-D6Eujc2zMxKjfa4Zxl4GHMsmhKKZ9VpcqIchJLvwTxad9zWIYulwYItBovpDOoNLISpcZSXoDJ5gaGbQUDqViA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -284,17 +294,17 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.27.1.tgz",
-      "integrity": "sha512-2KH4LWGSrJIkVf5tSiBFYuXDAoWRq2MMwgivCf+93dd0GQi8RXLjKA/0EvRnVV5G0hrHczsquXuD01L8s6dmBw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.28.6.tgz",
+      "integrity": "sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/plugin-syntax-jsx": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/plugin-syntax-jsx": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -358,48 +368,48 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.27.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.4.tgz",
-      "integrity": "sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.27.3",
-        "@babel/parser": "^7.27.4",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.27.3",
-        "debug": "^4.3.1",
-        "globals": "^11.1.0"
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.3.tgz",
-      "integrity": "sha512-Y1GkI4ktrtvmawoSq+4FCVHNryea6uR+qUQy0AGxLSsjCX0nVmkYQMBLHDkXZuo5hGx7eYdnIaslsdBFm7zbUw==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -438,69 +448,48 @@
       }
     },
     "node_modules/@ctrl/tinycolor": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-4.1.0.tgz",
-      "integrity": "sha512-WyOx8cJQ+FQus4Mm4uPIZA64gbk3Wxh0so5Lcii0aJifqwoVOlfFtorjLE0Hen4OYyHZMXDWqMmaQemBhgxFRQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-4.2.0.tgz",
+      "integrity": "sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==",
       "license": "MIT",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.8.tgz",
-      "integrity": "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.8"
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.12",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.12.tgz",
-      "integrity": "sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.8"
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
-      "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -513,20 +502,10 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@jridgewell/source-map": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -535,16 +514,16 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -553,27 +532,27 @@
       }
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.1.tgz",
-      "integrity": "sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@lit/react": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.6.tgz",
-      "integrity": "sha512-QIss8MPh6qUoFJmuaF4dSHts3qCsA36S3HcOLiNPShxhgYPr4XJRnCBKPipk85sR9xr6TQrOcDMfexwbNdJHYA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.8.tgz",
+      "integrity": "sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==",
       "license": "BSD-3-Clause",
       "peerDependencies": {
-        "@types/react": "17 || 18"
+        "@types/react": "17 || 18 || 19"
       }
     },
     "node_modules/@lit/reactive-element": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
-      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0"
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -611,21 +590,12 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@rollup/plugin-babel": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-6.0.4.tgz",
       "integrity": "sha512-YF7Y52kFdFT/xVSuVdjkV5ZdX/3YtmX0QulG+x0taQOtJdHYzVU61aSSkAgVJ7NOv6qPkIYiJSgSWWN/DM5sGw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.18.6",
         "@rollup/pluginutils": "^5.0.1"
@@ -743,9 +713,9 @@
       }
     },
     "node_modules/@rollup/pluginutils": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.3.tgz",
-      "integrity": "sha512-Pnsb6f32CD2W3uCaLZIzDmeFyQ2b8UWMFI7xtwUezpcGBDVDW6y9XgAWIlARiGAo6eNF5FK5aQTr0LFyNyqq5A==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -766,9 +736,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.41.1.tgz",
-      "integrity": "sha512-NELNvyEWZ6R9QMkiytB4/L4zSEaBC03KIXEghptLGLZWJ6VPrL63ooZQCOnlx36aQPGhzuOMwDerC1Eb2VmrLw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
       "cpu": [
         "arm"
       ],
@@ -780,9 +750,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.41.1.tgz",
-      "integrity": "sha512-DXdQe1BJ6TK47ukAoZLehRHhfKnKg9BjnQYUu9gzhI8Mwa1d2fzxA1aw2JixHVl403bwp1+/o/NhhHtxWJBgEA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
       "cpu": [
         "arm64"
       ],
@@ -794,9 +764,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.41.1.tgz",
-      "integrity": "sha512-5afxvwszzdulsU2w8JKWwY8/sJOLPzf0e1bFuvcW5h9zsEg+RQAojdW0ux2zyYAz7R8HvvzKCjLNJhVq965U7w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
       "cpu": [
         "arm64"
       ],
@@ -808,9 +778,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.41.1.tgz",
-      "integrity": "sha512-egpJACny8QOdHNNMZKf8xY0Is6gIMz+tuqXlusxquWu3F833DcMwmGM7WlvCO9sB3OsPjdC4U0wHw5FabzCGZg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
       "cpu": [
         "x64"
       ],
@@ -822,9 +792,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.41.1.tgz",
-      "integrity": "sha512-DBVMZH5vbjgRk3r0OzgjS38z+atlupJ7xfKIDJdZZL6sM6wjfDNo64aowcLPKIx7LMQi8vybB56uh1Ftck/Atg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
       "cpu": [
         "arm64"
       ],
@@ -836,9 +806,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.41.1.tgz",
-      "integrity": "sha512-3FkydeohozEskBxNWEIbPfOE0aqQgB6ttTkJ159uWOFn42VLyfAiyD9UK5mhu+ItWzft60DycIN1Xdgiy8o/SA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
       "cpu": [
         "x64"
       ],
@@ -850,9 +820,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.41.1.tgz",
-      "integrity": "sha512-wC53ZNDgt0pqx5xCAgNunkTzFE8GTgdZ9EwYGVcg+jEjJdZGtq9xPjDnFgfFozQI/Xm1mh+D9YlYtl+ueswNEg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
       "cpu": [
         "arm"
       ],
@@ -864,9 +834,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.41.1.tgz",
-      "integrity": "sha512-jwKCca1gbZkZLhLRtsrka5N8sFAaxrGz/7wRJ8Wwvq3jug7toO21vWlViihG85ei7uJTpzbXZRcORotE+xyrLA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
       "cpu": [
         "arm"
       ],
@@ -878,9 +848,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.41.1.tgz",
-      "integrity": "sha512-g0UBcNknsmmNQ8V2d/zD2P7WWfJKU0F1nu0k5pW4rvdb+BIqMm8ToluW/eeRmxCared5dD76lS04uL4UaNgpNA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
       "cpu": [
         "arm64"
       ],
@@ -892,9 +862,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.41.1.tgz",
-      "integrity": "sha512-XZpeGB5TKEZWzIrj7sXr+BEaSgo/ma/kCgrZgL0oo5qdB1JlTzIYQKel/RmhT6vMAvOdM2teYlAaOGJpJ9lahg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
       "cpu": [
         "arm64"
       ],
@@ -905,10 +875,10 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.41.1.tgz",
-      "integrity": "sha512-bkCfDJ4qzWfFRCNt5RVV4DOw6KEgFTUZi2r2RuYhGWC8WhCA8lCAJhDeAmrM/fdiAH54m0mA0Vk2FGRPyzI+tw==",
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
       "cpu": [
         "loong64"
       ],
@@ -919,10 +889,38 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.41.1.tgz",
-      "integrity": "sha512-3mr3Xm+gvMX+/8EKogIZSIEF0WUu0HL9di+YWlJpO8CQBnoLAEL/roTCxuLncEdgcfJcvA4UMOf+2dnjl4Ut1A==",
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
       "cpu": [
         "ppc64"
       ],
@@ -934,9 +932,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.41.1.tgz",
-      "integrity": "sha512-3rwCIh6MQ1LGrvKJitQjZFuQnT2wxfU+ivhNBzmxXTXPllewOF7JR1s2vMX/tWtUYFgphygxjqMl76q4aMotGw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
       "cpu": [
         "riscv64"
       ],
@@ -948,9 +946,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.41.1.tgz",
-      "integrity": "sha512-LdIUOb3gvfmpkgFZuccNa2uYiqtgZAz3PTzjuM5bH3nvuy9ty6RGc/Q0+HDFrHrizJGVpjnTZ1yS5TNNjFlklw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
       "cpu": [
         "riscv64"
       ],
@@ -962,9 +960,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.41.1.tgz",
-      "integrity": "sha512-oIE6M8WC9ma6xYqjvPhzZYk6NbobIURvP/lEbh7FWplcMO6gn7MM2yHKA1eC/GvYwzNKK/1LYgqzdkZ8YFxR8g==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
       "cpu": [
         "s390x"
       ],
@@ -976,9 +974,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.41.1.tgz",
-      "integrity": "sha512-cWBOvayNvA+SyeQMp79BHPK8ws6sHSsYnK5zDcsC3Hsxr1dgTABKjMnMslPq1DvZIp6uO7kIWhiGwaTdR4Og9A==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
       "cpu": [
         "x64"
       ],
@@ -990,9 +988,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.41.1.tgz",
-      "integrity": "sha512-y5CbN44M+pUCdGDlZFzGGBSKCA4A/J2ZH4edTYSSxFg7ce1Xt3GtydbVKWLlzL+INfFIZAEg1ZV6hh9+QQf9YQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
       "cpu": [
         "x64"
       ],
@@ -1003,10 +1001,38 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.41.1.tgz",
-      "integrity": "sha512-lZkCxIrjlJlMt1dLO/FbpZbzt6J/A8p4DnqzSa4PWqPEUUUnzXLeki/iyPLfV0BmHItlYgHUqJe+3KiyydmiNQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
       "cpu": [
         "arm64"
       ],
@@ -1018,9 +1044,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.41.1.tgz",
-      "integrity": "sha512-+psFT9+pIh2iuGsxFYYa/LhS5MFKmuivRsx9iPJWNSGbh2XVEjk90fmpUEjCnILPEPJnikAU6SFDiEUyOv90Pg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
       "cpu": [
         "ia32"
       ],
@@ -1031,10 +1057,24 @@
         "win32"
       ]
     },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.41.1.tgz",
-      "integrity": "sha512-Wq2zpapRYLfi4aKxf2Xff0tN+7slj2d4R87WEzqw7ZLsVvO5zwYCIuEGSZYiK41+GlwUo1HiR+GdkLEJnCKTCw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
       "cpu": [
         "x64"
       ],
@@ -1084,20 +1124,10 @@
         "url": "https://github.com/sponsors/claviska"
       }
     },
-    "node_modules/@trysound/sax": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
-      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/@types/estree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1111,31 +1141,25 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
       "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==",
-      "dev": true
-    },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.13",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
-      "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
-      "license": "MIT",
-      "peer": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.3.12",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.12.tgz",
-      "integrity": "sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==",
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -1144,10 +1168,11 @@
       "license": "MIT"
     },
     "node_modules/@web/parse5-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@web/parse5-utils/-/parse5-utils-2.1.0.tgz",
-      "integrity": "sha512-GzfK5disEJ6wEjoPwx8AVNwUe9gYIiwc+x//QYxYDAFKUp4Xb1OJAGLc2l2gVrSQmtPGLKrTRcW90Hv4pEq1qA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@web/parse5-utils/-/parse5-utils-2.1.1.tgz",
+      "integrity": "sha512-7rBVZEMGfrq2iPcAEwJ0KSNSvmA2a6jT2CK8/gyIOHgn4reg7bSSRbzyWIEYWyIkeRoYEukX/aW+nAeCgSSqhQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/parse5": "^6.0.1",
         "parse5": "^6.0.1"
@@ -1161,6 +1186,7 @@
       "resolved": "https://registry.npmjs.org/@web/rollup-plugin-html/-/rollup-plugin-html-2.3.0.tgz",
       "integrity": "sha512-ap4AisBacK6WwrTnVlPErupxlywWU1ELsjGIMZ4VpofvhbVTBIGErJo5VEj2mSJyEH3I1EbzUcWuhDCePrnWEw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@web/parse5-utils": "^2.1.0",
         "glob": "^10.0.0",
@@ -1173,46 +1199,12 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@web/rollup-plugin-html/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@web/rollup-plugin-html/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@web/rollup-plugin-html/node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -1250,18 +1242,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/ansi-styles": {
@@ -1311,9 +1291,9 @@
       "license": "MIT"
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.20",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
-      "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
+      "version": "10.4.27",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
+      "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
       "funding": [
         {
           "type": "opencollective",
@@ -1331,11 +1311,10 @@
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "browserslist": "^4.23.3",
-        "caniuse-lite": "^1.0.30001646",
-        "fraction.js": "^4.3.7",
-        "normalize-range": "^0.1.2",
-        "picocolors": "^1.0.1",
+        "browserslist": "^4.28.1",
+        "caniuse-lite": "^1.0.30001774",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
       },
       "bin": {
@@ -1349,10 +1328,25 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
+      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -1374,13 +1368,15 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -1396,9 +1392,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
-      "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "funding": [
         {
           "type": "opencollective",
@@ -1415,10 +1411,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001669",
-        "electron-to-chromium": "^1.5.41",
-        "node-releases": "^2.0.18",
-        "update-browserslist-db": "^1.1.1"
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1486,9 +1483,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001676",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001676.tgz",
-      "integrity": "sha512-Qz6zwGCiPghQXGJvgQAem79esjitvJ+CxSbSQkW9H/UX5hg8XM88d4lp2W+MEQ81j+Hip58Il+jGVdazk1z9cw==",
+      "version": "1.0.30001777",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz",
+      "integrity": "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -1644,12 +1641,6 @@
         "@floating-ui/utils": "^0.2.5"
       }
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "license": "MIT"
-    },
     "node_modules/concat-with-sourcemaps": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz",
@@ -1664,15 +1655,20 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
-      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cosmiconfig": {
@@ -1689,20 +1685,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/css-color-names": {
@@ -1728,16 +1710,16 @@
       }
     },
     "node_modules/css-select": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
-        "css-what": "^6.0.1",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
         "nth-check": "^2.0.1"
       },
       "funding": {
@@ -1745,17 +1727,17 @@
       }
     },
     "node_modules/css-tree": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.0.14",
-        "source-map": "^0.6.1"
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/css-unit-converter": {
@@ -1765,9 +1747,9 @@
       "license": "MIT"
     },
     "node_modules/css-what": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -1869,29 +1851,52 @@
       }
     },
     "node_modules/csso": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
-      "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "css-tree": "^1.1.2"
+        "css-tree": "~2.2.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
       }
     },
+    "node_modules/csso/node_modules/css-tree": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/mdn-data": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1926,15 +1931,13 @@
       }
     },
     "node_modules/detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
-      "bin": {
-        "detect-libc": "bin/detect-libc.js"
-      },
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=0.10"
+        "node": ">=8"
       }
     },
     "node_modules/detective": {
@@ -1967,28 +1970,18 @@
       "license": "MIT"
     },
     "node_modules/dom-serializer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
       },
       "funding": {
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/dom-serializer/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/domelementtype": {
@@ -2005,13 +1998,13 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "domelementtype": "^2.2.0"
+        "domelementtype": "^2.3.0"
       },
       "engines": {
         "node": ">= 4"
@@ -2021,15 +2014,15 @@
       }
     },
     "node_modules/domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
@@ -2046,16 +2039,10 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true
-    },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.50",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.50.tgz",
-      "integrity": "sha512-eMVObiUQ2LdgeO1F/ySTXsvqvxb6ZH2zPGaMYsWzRDdOddUa77tdmI0ltg+L16UpbWdhPmuF3wIQYyQq65WfZw==",
+      "version": "1.5.307",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
+      "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -2069,12 +2056,6 @@
       "funding": {
         "url": "https://github.com/sindresorhus/emittery?sponsor=1"
       }
-    },
-    "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -2090,9 +2071,9 @@
       }
     },
     "node_modules/error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -2122,16 +2103,16 @@
       "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -2150,19 +2131,23 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
-      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
       }
     },
     "node_modules/fdir": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
-      "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -2184,33 +2169,17 @@
         "node": ">=8"
       }
     },
-    "node_modules/foreground-child": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
-      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/fraction.js": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": "*"
       },
       "funding": {
-        "type": "patreon",
+        "type": "github",
         "url": "https://github.com/sponsors/rawify"
       }
     },
@@ -2227,12 +2196,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2277,6 +2240,23 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2287,16 +2267,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/graceful-fs": {
@@ -2412,9 +2382,9 @@
       }
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -2449,23 +2419,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -2499,9 +2452,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -2520,15 +2473,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -2569,27 +2513,6 @@
         "@types/estree": "*"
       }
     },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
-    },
-    "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2597,9 +2520,9 @@
       "license": "MIT"
     },
     "node_modules/jsesc": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2629,9 +2552,9 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -2641,12 +2564,13 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.28.1.tgz",
-      "integrity": "sha512-KRDkHlLlNj3DWh79CDt93fPlRJh2W1AuHV0ZSZAMMuN7lqlsZTV5842idfS1urWG8q9tc17velp1gCXhY7sLnQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
-        "detect-libc": "^1.0.3"
+        "detect-libc": "^2.0.3"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -2656,26 +2580,49 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.28.1",
-        "lightningcss-darwin-x64": "1.28.1",
-        "lightningcss-freebsd-x64": "1.28.1",
-        "lightningcss-linux-arm-gnueabihf": "1.28.1",
-        "lightningcss-linux-arm64-gnu": "1.28.1",
-        "lightningcss-linux-arm64-musl": "1.28.1",
-        "lightningcss-linux-x64-gnu": "1.28.1",
-        "lightningcss-linux-x64-musl": "1.28.1",
-        "lightningcss-win32-arm64-msvc": "1.28.1",
-        "lightningcss-win32-x64-msvc": "1.28.1"
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.28.1.tgz",
-      "integrity": "sha512-VG3vvzM0m/rguCdm76DdobNeNJnHK+jWcdkNLFWHLh9YCotRvbRIt45JxwcHlIF8TDqWStVLTdghq5NaigVCBQ==",
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -2689,13 +2636,14 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.28.1.tgz",
-      "integrity": "sha512-O7ORdislvKfMohFl4Iq7fxKqdJOuuxArcglVI3amuFO5DJ0wfV3Gxgi1JRo49slfr7OVzJQEHLG4muTWYM5cTQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -2709,13 +2657,14 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.28.1.tgz",
-      "integrity": "sha512-b7sF89B31kYYijxVcFO7l5u6UNA862YstNu+3YbLl/IQKzveL4a5cwR5cdpG+OOhErg/c2u9WCmzZoX2I5GBvw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "freebsd"
@@ -2729,13 +2678,14 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.28.1.tgz",
-      "integrity": "sha512-p61kXwvhUDLLzkWHjzSFfUBW/F0iy3jr3CWi3k8SKULtJEsJXTI9DqRm9EixxMSe2AMBQBt4auTYiQL4B1N51A==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -2749,13 +2699,14 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.28.1.tgz",
-      "integrity": "sha512-iO+fN9hOMmzfwqcG2/BgUtMKD48H2JO/SXU44fyIwpY2veb65QF5xiRrQ9l1FwIxbGK3231KBYCtAqv+xf+NsQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -2769,13 +2720,14 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.28.1.tgz",
-      "integrity": "sha512-dnMHeXEmCUzHHZjaDpQBYuBKcN9nPC3nPFKl70bcj5Bkn5EmkcgEqm5p035LKOgvAwk1XwLpQCML6pXmCwz0NQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -2789,13 +2741,14 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.28.1.tgz",
-      "integrity": "sha512-7vWDISaMUn+oo2TwRdf2hl/BLdPxvywv9JKEqNZB/0K7bXwV4XE9wN/C2sAp1gGuh6QBA8lpjF4JIPt3HNlCHA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -2809,13 +2762,14 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.28.1.tgz",
-      "integrity": "sha512-IHCu9tVGP+x5BCpA2rF3D04DBokcBza/a8AuHQU+1AiMKubuMegPwcL7RatBgK4ztFHeYnnD5NdhwhRfYMAtNA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -2829,13 +2783,14 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.28.1.tgz",
-      "integrity": "sha512-Erm72kHmMg/3h350PTseskz+eEGBM17Fuu79WW2Qqt0BfWSF1jHHc12lkJCWMYl5jcBHPs5yZdgNHtJ7IJS3Uw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -2849,13 +2804,14 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.28.1.tgz",
-      "integrity": "sha512-ZPQtvx+uQBzrSdHH8p4H3M9Alue+x369TPZAA3b4K3d92FPhpZCuBG04+HQzspam9sVeID9mI6f3VRAs2ezaEA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -2884,31 +2840,31 @@
       "license": "MIT"
     },
     "node_modules/lit": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
-      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/reactive-element": "^2.0.4",
-        "lit-element": "^4.1.0",
-        "lit-html": "^3.2.0"
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
       }
     },
     "node_modules/lit-element": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
-      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0",
-        "@lit/reactive-element": "^2.0.4",
-        "lit-html": "^3.2.0"
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
       }
     },
     "node_modules/lit-html": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
-      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
@@ -2925,9 +2881,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -2978,18 +2934,19 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.13",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.13.tgz",
-      "integrity": "sha512-8rYBO+MsWkgjDSOvLomYnzhdwEG51olQ4zL5KXnNJWV5MNmrb4rTZdrtkhxjnD/QyZUqR/Z/XDsUs/4ej2nx0g==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -3027,6 +2984,21 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -3037,10 +3009,10 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -3103,9 +3075,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "license": "MIT"
     },
     "node_modules/normalize-path": {
@@ -3113,16 +3085,6 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/normalize-range": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-      "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3160,15 +3122,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
       }
     },
     "node_modules/p-finally": {
@@ -3210,12 +3163,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true
     },
     "node_modules/param-case": {
       "version": "3.0.4",
@@ -3262,7 +3209,8 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pascal-case": {
       "version": "3.1.2",
@@ -3275,24 +3223,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -3300,26 +3230,29 @@
       "license": "MIT"
     },
     "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.18"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -3337,9 +3270,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3363,9 +3296,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
-      "integrity": "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "funding": [
         {
           "type": "opencollective",
@@ -3676,14 +3609,14 @@
       }
     },
     "node_modules/postcss-modules-local-by-default": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.5.tgz",
-      "integrity": "sha512-6MieY7sIfTK0hYfafw1OMEG+2bg8Q1ocHCpoWLqOKj3JXlKu4G7btkmM/B7lFubYkYWmRSPLZi5chid63ZaZYw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.2.0.tgz",
+      "integrity": "sha512-5kcJm/zk+GJDSfw+V/42fJ5fhjL5YbFDl8nVdXkJPLLW+Vf9mTD5Xe0wqIaDnLuL2U6cDNpTr+UQ+v2HWIBhzw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "icss-utils": "^5.0.0",
-        "postcss-selector-parser": "^6.0.2",
+        "postcss-selector-parser": "^7.0.0",
         "postcss-value-parser": "^4.1.0"
       },
       "engines": {
@@ -3693,20 +3626,48 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/postcss-modules-local-by-default/node_modules/postcss-selector-parser": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/postcss-modules-scope": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.0.tgz",
-      "integrity": "sha512-oq+g1ssrsZOsx9M96c5w8laRmvEu9C3adDSjI8oTcbfkrTE8hx/zfyobUoWIxaKPO8bt6S62kxpw5GqypEw1QQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.1.tgz",
+      "integrity": "sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "postcss-selector-parser": "^6.0.4"
+        "postcss-selector-parser": "^7.0.0"
       },
       "engines": {
         "node": "^10 || ^12 || >= 14"
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-scope/node_modules/postcss-selector-parser": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/postcss-modules-values": {
@@ -4023,16 +3984,6 @@
         "purgecss": "bin/purgecss.js"
       }
     },
-    "node_modules/purgecss/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/purgecss/node_modules/commander": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
@@ -4040,39 +3991,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/purgecss/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/purgecss/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/qr-creator": {
@@ -4135,9 +4053,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.1.tgz",
-      "integrity": "sha512-hPJXXxHJZEsPFNVbtATH7+MMX43UDeOauz+EAU4cgqTn7ojdI9qQORqS8Z0qmDlL1TclO/6jLRYUEtbWidtdHQ==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
+      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -4157,12 +4075,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.1.tgz",
-      "integrity": "sha512-vxU7ei//UfPYQ3iZvHuO1D/5fX3/JOqhNTbRR+WjSBWxf9bIvpWK+ftjmdfJHzPOuMQKe2fiEdG+dZX6E8uUpA==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
+      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.6.1"
+        "react-router": "7.13.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -4223,17 +4141,20 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.13.0",
+        "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4250,9 +4171,9 @@
       }
     },
     "node_modules/reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -4272,13 +4193,13 @@
       "license": "MIT"
     },
     "node_modules/rollup": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.41.1.tgz",
-      "integrity": "sha512-cPmwD3FnFv8rKMBc1MxWCwVQFxwf1JEmSX3iQXrRVVG15zerAIXRjMFVWnd5Q5QvgKF7Aj+5ykXFhUl+QGnyOw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.7"
+        "@types/estree": "1.0.8"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -4288,26 +4209,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.41.1",
-        "@rollup/rollup-android-arm64": "4.41.1",
-        "@rollup/rollup-darwin-arm64": "4.41.1",
-        "@rollup/rollup-darwin-x64": "4.41.1",
-        "@rollup/rollup-freebsd-arm64": "4.41.1",
-        "@rollup/rollup-freebsd-x64": "4.41.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.41.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.41.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.41.1",
-        "@rollup/rollup-linux-arm64-musl": "4.41.1",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.41.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.41.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.41.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.41.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.41.1",
-        "@rollup/rollup-linux-x64-gnu": "4.41.1",
-        "@rollup/rollup-linux-x64-musl": "4.41.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.41.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.41.1",
-        "@rollup/rollup-win32-x64-msvc": "4.41.1",
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -4386,6 +4312,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sax": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
+      "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -4403,57 +4339,24 @@
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
-    "node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }
     },
     "node_modules/simple-swizzle/node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
       "license": "MIT"
     },
     "node_modules/source-map": {
@@ -4486,116 +4389,12 @@
         "source-map": "^0.6.0"
       }
     },
-    "node_modules/stable": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-      "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/string-hash": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
       "integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==",
       "dev": true,
       "license": "CC0-1.0"
-    },
-    "node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
-    },
-    "node_modules/string-width-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/style-inject": {
       "version": "0.3.0",
@@ -4646,35 +4445,39 @@
       }
     },
     "node_modules/svgo": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-      "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
+      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@trysound/sax": "0.2.0",
-        "commander": "^7.2.0",
-        "css-select": "^4.1.3",
-        "css-tree": "^1.1.3",
-        "csso": "^4.2.0",
-        "picocolors": "^1.0.0",
-        "stable": "^0.1.8"
+        "commander": "^11.1.0",
+        "css-select": "^5.1.0",
+        "css-tree": "^3.0.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.1.1",
+        "sax": "^1.5.0"
       },
       "bin": {
-        "svgo": "bin/svgo"
+        "svgo": "bin/svgo.js"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
       }
     },
     "node_modules/svgo/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 10"
+        "node": ">=16"
       }
     },
     "node_modules/tailwindcss": {
@@ -4729,14 +4532,14 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.36.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.36.0.tgz",
-      "integrity": "sha512-IYV9eNMuFAV4THUspIRXkLakHnV6XO7FEdtKjf/mDyrnqUg9LnlOn6/RwRvM9SZjR4GUq8Nk8zj67FzVARr74w==",
+      "version": "5.46.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
+      "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
+        "acorn": "^8.15.0",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },
@@ -4748,9 +4551,9 @@
       }
     },
     "node_modules/terser/node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4768,9 +4571,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
@@ -4811,9 +4614,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
-      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "funding": [
         {
           "type": "opencollective",
@@ -4831,7 +4634,7 @@
       "license": "MIT",
       "dependencies": {
         "escalade": "^3.2.0",
-        "picocolors": "^1.1.0"
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -4858,115 +4661,6 @@
       "bin": {
         "uuid": "dist-node/bin/uuid"
       }
-    },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/ui/extensions/Third-party Detections/package.json
+++ b/ui/extensions/Third-party Detections/package.json
@@ -12,7 +12,7 @@
     "@shoelace-style/shoelace": "^2.20.1",
     "react": "19.2.1",
     "react-dom": "19.2.1",
-    "react-router-dom": "7.6.1"
+    "react-router-dom": "7.13.1"
   },
   "devDependencies": {
     "@babel/core": "7.27.4",
@@ -24,8 +24,16 @@
     "@rollup/plugin-replace": "6.0.2",
     "@web/rollup-plugin-html": "2.3.0",
     "postcss": "^8.5.4",
-    "rollup": "4.41.1",
+    "rollup": "4.59.0",
     "rollup-plugin-postcss": "^4.0.2"
+  },
+  "overrides": {
+    "svgo": ">=2.8.1",
+    "minimatch": ">=3.1.4",
+    "glob": ">=10.5.0",
+    "lodash": ">=4.17.23",
+    "tmp": ">=0.2.4",
+    "brace-expansion": ">=1.1.12"
   },
   "scripts": {
     "build": "rollup -c ./config/rollup.config.js",

--- a/ui/extensions/Third-party Detections/src/dist/app.js
+++ b/ui/extensions/Third-party Detections/src/dist/app.js
@@ -433,248 +433,8 @@ var React$1 = /*#__PURE__*/_mergeNamespaces({
 	default: React
 }, [reactExports]);
 
-var dist = {};
-
-var hasRequiredDist;
-
-function requireDist () {
-	if (hasRequiredDist) return dist;
-	hasRequiredDist = 1;
-
-	Object.defineProperty(dist, "__esModule", {
-	  value: true
-	});
-	dist.parse = parse;
-	dist.serialize = serialize;
-	/**
-	 * RegExp to match cookie-name in RFC 6265 sec 4.1.1
-	 * This refers out to the obsoleted definition of token in RFC 2616 sec 2.2
-	 * which has been replaced by the token definition in RFC 7230 appendix B.
-	 *
-	 * cookie-name       = token
-	 * token             = 1*tchar
-	 * tchar             = "!" / "#" / "$" / "%" / "&" / "'" /
-	 *                     "*" / "+" / "-" / "." / "^" / "_" /
-	 *                     "`" / "|" / "~" / DIGIT / ALPHA
-	 *
-	 * Note: Allowing more characters - https://github.com/jshttp/cookie/issues/191
-	 * Allow same range as cookie value, except `=`, which delimits end of name.
-	 */
-	const cookieNameRegExp = /^[\u0021-\u003A\u003C\u003E-\u007E]+$/;
-	/**
-	 * RegExp to match cookie-value in RFC 6265 sec 4.1.1
-	 *
-	 * cookie-value      = *cookie-octet / ( DQUOTE *cookie-octet DQUOTE )
-	 * cookie-octet      = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
-	 *                     ; US-ASCII characters excluding CTLs,
-	 *                     ; whitespace DQUOTE, comma, semicolon,
-	 *                     ; and backslash
-	 *
-	 * Allowing more characters: https://github.com/jshttp/cookie/issues/191
-	 * Comma, backslash, and DQUOTE are not part of the parsing algorithm.
-	 */
-	const cookieValueRegExp = /^[\u0021-\u003A\u003C-\u007E]*$/;
-	/**
-	 * RegExp to match domain-value in RFC 6265 sec 4.1.1
-	 *
-	 * domain-value      = <subdomain>
-	 *                     ; defined in [RFC1034], Section 3.5, as
-	 *                     ; enhanced by [RFC1123], Section 2.1
-	 * <subdomain>       = <label> | <subdomain> "." <label>
-	 * <label>           = <let-dig> [ [ <ldh-str> ] <let-dig> ]
-	 *                     Labels must be 63 characters or less.
-	 *                     'let-dig' not 'letter' in the first char, per RFC1123
-	 * <ldh-str>         = <let-dig-hyp> | <let-dig-hyp> <ldh-str>
-	 * <let-dig-hyp>     = <let-dig> | "-"
-	 * <let-dig>         = <letter> | <digit>
-	 * <letter>          = any one of the 52 alphabetic characters A through Z in
-	 *                     upper case and a through z in lower case
-	 * <digit>           = any one of the ten digits 0 through 9
-	 *
-	 * Keep support for leading dot: https://github.com/jshttp/cookie/issues/173
-	 *
-	 * > (Note that a leading %x2E ("."), if present, is ignored even though that
-	 * character is not permitted, but a trailing %x2E ("."), if present, will
-	 * cause the user agent to ignore the attribute.)
-	 */
-	const domainValueRegExp = /^([.]?[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)([.][a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$/i;
-	/**
-	 * RegExp to match path-value in RFC 6265 sec 4.1.1
-	 *
-	 * path-value        = <any CHAR except CTLs or ";">
-	 * CHAR              = %x01-7F
-	 *                     ; defined in RFC 5234 appendix B.1
-	 */
-	const pathValueRegExp = /^[\u0020-\u003A\u003D-\u007E]*$/;
-	const __toString = Object.prototype.toString;
-	const NullObject = /* @__PURE__ */(() => {
-	  const C = function () {};
-	  C.prototype = Object.create(null);
-	  return C;
-	})();
-	/**
-	 * Parse a cookie header.
-	 *
-	 * Parse the given cookie header string into an object
-	 * The object has the various cookies as keys(names) => values
-	 */
-	function parse(str, options) {
-	  const obj = new NullObject();
-	  const len = str.length;
-	  // RFC 6265 sec 4.1.1, RFC 2616 2.2 defines a cookie name consists of one char minimum, plus '='.
-	  if (len < 2) return obj;
-	  const dec = options?.decode || decode;
-	  let index = 0;
-	  do {
-	    const eqIdx = str.indexOf("=", index);
-	    if (eqIdx === -1) break; // No more cookie pairs.
-	    const colonIdx = str.indexOf(";", index);
-	    const endIdx = colonIdx === -1 ? len : colonIdx;
-	    if (eqIdx > endIdx) {
-	      // backtrack on prior semicolon
-	      index = str.lastIndexOf(";", eqIdx - 1) + 1;
-	      continue;
-	    }
-	    const keyStartIdx = startIndex(str, index, eqIdx);
-	    const keyEndIdx = endIndex(str, eqIdx, keyStartIdx);
-	    const key = str.slice(keyStartIdx, keyEndIdx);
-	    // only assign once
-	    if (obj[key] === undefined) {
-	      let valStartIdx = startIndex(str, eqIdx + 1, endIdx);
-	      let valEndIdx = endIndex(str, endIdx, valStartIdx);
-	      const value = dec(str.slice(valStartIdx, valEndIdx));
-	      obj[key] = value;
-	    }
-	    index = endIdx + 1;
-	  } while (index < len);
-	  return obj;
-	}
-	function startIndex(str, index, max) {
-	  do {
-	    const code = str.charCodeAt(index);
-	    if (code !== 0x20 /*   */ && code !== 0x09 /* \t */) return index;
-	  } while (++index < max);
-	  return max;
-	}
-	function endIndex(str, index, min) {
-	  while (index > min) {
-	    const code = str.charCodeAt(--index);
-	    if (code !== 0x20 /*   */ && code !== 0x09 /* \t */) return index + 1;
-	  }
-	  return min;
-	}
-	/**
-	 * Serialize data into a cookie header.
-	 *
-	 * Serialize a name value pair into a cookie string suitable for
-	 * http headers. An optional options object specifies cookie parameters.
-	 *
-	 * serialize('foo', 'bar', { httpOnly: true })
-	 *   => "foo=bar; httpOnly"
-	 */
-	function serialize(name, val, options) {
-	  const enc = options?.encode || encodeURIComponent;
-	  if (!cookieNameRegExp.test(name)) {
-	    throw new TypeError(`argument name is invalid: ${name}`);
-	  }
-	  const value = enc(val);
-	  if (!cookieValueRegExp.test(value)) {
-	    throw new TypeError(`argument val is invalid: ${val}`);
-	  }
-	  let str = name + "=" + value;
-	  if (!options) return str;
-	  if (options.maxAge !== undefined) {
-	    if (!Number.isInteger(options.maxAge)) {
-	      throw new TypeError(`option maxAge is invalid: ${options.maxAge}`);
-	    }
-	    str += "; Max-Age=" + options.maxAge;
-	  }
-	  if (options.domain) {
-	    if (!domainValueRegExp.test(options.domain)) {
-	      throw new TypeError(`option domain is invalid: ${options.domain}`);
-	    }
-	    str += "; Domain=" + options.domain;
-	  }
-	  if (options.path) {
-	    if (!pathValueRegExp.test(options.path)) {
-	      throw new TypeError(`option path is invalid: ${options.path}`);
-	    }
-	    str += "; Path=" + options.path;
-	  }
-	  if (options.expires) {
-	    if (!isDate(options.expires) || !Number.isFinite(options.expires.valueOf())) {
-	      throw new TypeError(`option expires is invalid: ${options.expires}`);
-	    }
-	    str += "; Expires=" + options.expires.toUTCString();
-	  }
-	  if (options.httpOnly) {
-	    str += "; HttpOnly";
-	  }
-	  if (options.secure) {
-	    str += "; Secure";
-	  }
-	  if (options.partitioned) {
-	    str += "; Partitioned";
-	  }
-	  if (options.priority) {
-	    const priority = typeof options.priority === "string" ? options.priority.toLowerCase() : undefined;
-	    switch (priority) {
-	      case "low":
-	        str += "; Priority=Low";
-	        break;
-	      case "medium":
-	        str += "; Priority=Medium";
-	        break;
-	      case "high":
-	        str += "; Priority=High";
-	        break;
-	      default:
-	        throw new TypeError(`option priority is invalid: ${options.priority}`);
-	    }
-	  }
-	  if (options.sameSite) {
-	    const sameSite = typeof options.sameSite === "string" ? options.sameSite.toLowerCase() : options.sameSite;
-	    switch (sameSite) {
-	      case true:
-	      case "strict":
-	        str += "; SameSite=Strict";
-	        break;
-	      case "lax":
-	        str += "; SameSite=Lax";
-	        break;
-	      case "none":
-	        str += "; SameSite=None";
-	        break;
-	      default:
-	        throw new TypeError(`option sameSite is invalid: ${options.sameSite}`);
-	    }
-	  }
-	  return str;
-	}
-	/**
-	 * URL-decode string value. Optimized to skip native call when no %.
-	 */
-	function decode(str) {
-	  if (str.indexOf("%") === -1) return str;
-	  try {
-	    return decodeURIComponent(str);
-	  } catch (e) {
-	    return str;
-	  }
-	}
-	/**
-	 * Determine if value is a Date.
-	 */
-	function isDate(val) {
-	  return __toString.call(val) === "[object Date]";
-	}
-	return dist;
-}
-
-requireDist();
-
 /**
- * react-router v7.6.1
+ * react-router v7.13.1
  *
  * Copyright (c) Remix Software Inc.
  *
@@ -684,6 +444,9 @@ requireDist();
  * @license MIT
  */
 var PopStateEventType = "popstate";
+function isLocation(obj) {
+  return typeof obj === "object" && obj != null && "pathname" in obj && "search" in obj && "hash" in obj && "state" in obj && "key" in obj;
+}
 function createHashHistory(options = {}) {
   function createHashLocation(window2, globalHistory) {
     let {
@@ -704,13 +467,13 @@ function createHashHistory(options = {}) {
   }
   function createHashHref(window2, to) {
     let base = window2.document.querySelector("base");
-    let href2 = "";
+    let href = "";
     if (base && base.getAttribute("href")) {
       let url = window2.location.href;
       let hashIndex = url.indexOf("#");
-      href2 = hashIndex === -1 ? url : url.slice(0, hashIndex);
+      href = hashIndex === -1 ? url : url.slice(0, hashIndex);
     }
-    return href2 + "#" + (typeof to === "string" ? to : createPath(to));
+    return href + "#" + (typeof to === "string" ? to : createPath(to));
   }
   function validateHashLocation(location, to) {
     warning(location.pathname.charAt(0) === "/", `relative pathnames are not supported in hash history.push(${JSON.stringify(to)})`);
@@ -737,10 +500,15 @@ function getHistoryState(location, index) {
   return {
     usr: location.state,
     key: location.key,
-    idx: index
+    idx: index,
+    masked: location.unstable_mask ? {
+      pathname: location.pathname,
+      search: location.search,
+      hash: location.hash
+    } : void 0
   };
 }
-function createLocation(current, to, state = null, key) {
+function createLocation(current, to, state = null, key, unstable_mask) {
   let location = {
     pathname: typeof current === "string" ? current : current.pathname,
     search: "",
@@ -751,7 +519,8 @@ function createLocation(current, to, state = null, key) {
     // full Locations now and avoid the need to run through this flow at all
     // But that's a pretty big refactor to the current test suite so going to
     // keep as is for the time being and just let any incoming keys take precedence
-    key: to && to.key || key || createKey()
+    key: to && to.key || key || createKey(),
+    unstable_mask
   };
   return location;
 }
@@ -820,11 +589,11 @@ function getUrlBasedHistory(getLocation, createHref2, validateLocation, options 
   }
   function push(to, state) {
     action = "PUSH" /* Push */;
-    let location = createLocation(history.location, to, state);
+    let location = isLocation(to) ? to : createLocation(history.location, to, state);
     if (validateLocation) validateLocation(location, to);
     index = getIndex() + 1;
     let historyState = getHistoryState(location, index);
-    let url = history.createHref(location);
+    let url = history.createHref(location.unstable_mask || location);
     try {
       globalHistory.pushState(historyState, "", url);
     } catch (error) {
@@ -843,11 +612,11 @@ function getUrlBasedHistory(getLocation, createHref2, validateLocation, options 
   }
   function replace2(to, state) {
     action = "REPLACE" /* Replace */;
-    let location = createLocation(history.location, to, state);
+    let location = isLocation(to) ? to : createLocation(history.location, to, state);
     if (validateLocation) validateLocation(location, to);
     index = getIndex();
     let historyState = getHistoryState(location, index);
-    let url = history.createHref(location);
+    let url = history.createHref(location.unstable_mask || location);
     globalHistory.replaceState(historyState, "", url);
     if (v5Compat && listener) {
       listener({
@@ -904,12 +673,12 @@ function createBrowserURLImpl(to, isAbsolute = false) {
     base = window.location.origin !== "null" ? window.location.origin : window.location.href;
   }
   invariant(base, "No window.location.(origin|href) available to create URL");
-  let href2 = typeof to === "string" ? to : createPath(to);
-  href2 = href2.replace(/ $/, "%20");
-  if (!isAbsolute && href2.startsWith("//")) {
-    href2 = base + href2;
+  let href = typeof to === "string" ? to : createPath(to);
+  href = href.replace(/ $/, "%20");
+  if (!isAbsolute && href.startsWith("//")) {
+    href = base + href;
   }
-  return new URL(href2, base);
+  return new URL(href, base);
 }
 function matchRoutes(routes, locationArg, basename = "/") {
   return matchRoutesImpl(routes, locationArg, basename, false);
@@ -929,8 +698,8 @@ function matchRoutesImpl(routes, locationArg, basename, allowPartial) {
   }
   return matches;
 }
-function flattenRoutes(routes, branches = [], parentsMeta = [], parentPath = "") {
-  let flattenRoute = (route, index, relativePath) => {
+function flattenRoutes(routes, branches = [], parentsMeta = [], parentPath = "", _hasParentOptionalSegments = false) {
+  let flattenRoute = (route, index, hasParentOptionalSegments = _hasParentOptionalSegments, relativePath) => {
     let meta = {
       relativePath: relativePath === void 0 ? route.path || "" : relativePath,
       caseSensitive: route.caseSensitive === true,
@@ -938,6 +707,9 @@ function flattenRoutes(routes, branches = [], parentsMeta = [], parentPath = "")
       route
     };
     if (meta.relativePath.startsWith("/")) {
+      if (!meta.relativePath.startsWith(parentPath) && hasParentOptionalSegments) {
+        return;
+      }
       invariant(meta.relativePath.startsWith(parentPath), `Absolute route path "${meta.relativePath}" nested under path "${parentPath}" is not valid. An absolute child route path must start with the combined path of all its parent routes.`);
       meta.relativePath = meta.relativePath.slice(parentPath.length);
     }
@@ -948,7 +720,7 @@ function flattenRoutes(routes, branches = [], parentsMeta = [], parentPath = "")
       // Our types know better, but runtime JS may not!
       // @ts-expect-error
       route.index !== true, `Index routes must not have child routes. Please remove all child routes from route path "${path}".`);
-      flattenRoutes(route.children, branches, routesMeta, path);
+      flattenRoutes(route.children, branches, routesMeta, path, hasParentOptionalSegments);
     }
     if (route.path == null && !route.index) {
       return;
@@ -964,7 +736,7 @@ function flattenRoutes(routes, branches = [], parentsMeta = [], parentPath = "")
       flattenRoute(route, index);
     } else {
       for (let exploded of explodeOptionalSegments(route.path)) {
-        flattenRoute(route, index, exploded);
+        flattenRoute(route, index, true, exploded);
       }
     }
   });
@@ -1101,13 +873,20 @@ function matchPath(pattern, pathname) {
 function compilePath(path, caseSensitive = false, end = true) {
   warning(path === "*" || !path.endsWith("*") || path.endsWith("/*"), `Route path "${path}" will be treated as if it were "${path.replace(/\*$/, "/*")}" because the \`*\` character must always follow a \`/\` in the pattern. To get rid of this warning, please change the route path to "${path.replace(/\*$/, "/*")}".`);
   let params = [];
-  let regexpSource = "^" + path.replace(/\/*\*?$/, "").replace(/^\/*/, "/").replace(/[\\.*+^${}|()[\]]/g, "\\$&").replace(/\/:([\w-]+)(\?)?/g, (_, paramName, isOptional) => {
+  let regexpSource = "^" + path.replace(/\/*\*?$/, "").replace(/^\/*/, "/").replace(/[\\.*+^${}|()[\]]/g, "\\$&").replace(/\/:([\w-]+)(\?)?/g, (match, paramName, isOptional, index, str) => {
     params.push({
       paramName,
       isOptional: isOptional != null
     });
-    return isOptional ? "/?([^\\/]+)?" : "/([^\\/]+)";
-  });
+    if (isOptional) {
+      let nextChar = str.charAt(index + match.length);
+      if (nextChar && nextChar !== "/") {
+        return "/([^\\/]*)";
+      }
+      return "(?:/([^\\/]*))?";
+    }
+    return "/([^\\/]+)";
+  }).replace(/\/([\w-]+)\?(\/|$)/g, "(/$1)?$2");
   if (path.endsWith("*")) {
     params.push({
       paramName: "*"
@@ -1141,13 +920,24 @@ function stripBasename(pathname, basename) {
   }
   return pathname.slice(startIndex) || "/";
 }
+var ABSOLUTE_URL_REGEX = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
 function resolvePath(to, fromPathname = "/") {
   let {
     pathname: toPathname,
     search = "",
     hash = ""
   } = typeof to === "string" ? parsePath(to) : to;
-  let pathname = toPathname ? toPathname.startsWith("/") ? toPathname : resolvePathname(toPathname, fromPathname) : fromPathname;
+  let pathname;
+  if (toPathname) {
+    toPathname = toPathname.replace(/\/\/+/g, "/");
+    if (toPathname.startsWith("/")) {
+      pathname = resolvePathname(toPathname.substring(1), "/");
+    } else {
+      pathname = resolvePathname(toPathname, fromPathname);
+    }
+  } else {
+    pathname = fromPathname;
+  }
   return {
     pathname,
     search: normalizeSearch(search),
@@ -1217,9 +1007,52 @@ var joinPaths = paths => paths.join("/").replace(/\/\/+/g, "/");
 var normalizePathname = pathname => pathname.replace(/\/+$/, "").replace(/^\/*/, "/");
 var normalizeSearch = search => !search || search === "?" ? "" : search.startsWith("?") ? search : "?" + search;
 var normalizeHash = hash => !hash || hash === "#" ? "" : hash.startsWith("#") ? hash : "#" + hash;
-function isRouteErrorResponse(error) {
-  return error != null && typeof error.status === "number" && typeof error.statusText === "string" && typeof error.internal === "boolean" && "data" in error;
+var ErrorResponseImpl = class {
+  constructor(status, statusText, data2, internal = false) {
+    this.status = status;
+    this.statusText = statusText || "";
+    this.internal = internal;
+    if (data2 instanceof Error) {
+      this.data = data2.toString();
+      this.error = data2;
+    } else {
+      this.data = data2;
+    }
+  }
+};
+var isBrowser = typeof window !== "undefined" && typeof window.document !== "undefined" && typeof window.document.createElement !== "undefined";
+function parseToInfo(_to, basename) {
+  let to = _to;
+  if (typeof to !== "string" || !ABSOLUTE_URL_REGEX.test(to)) {
+    return {
+      absoluteURL: void 0,
+      isExternal: false,
+      to
+    };
+  }
+  let absoluteURL = to;
+  let isExternal = false;
+  if (isBrowser) {
+    try {
+      let currentUrl = new URL(window.location.href);
+      let targetUrl = to.startsWith("//") ? new URL(currentUrl.protocol + to) : new URL(to);
+      let path = stripBasename(targetUrl.pathname, basename);
+      if (targetUrl.origin === currentUrl.origin && path != null) {
+        to = path + targetUrl.search + targetUrl.hash;
+      } else {
+        isExternal = true;
+      }
+    } catch (e) {
+      warning(false, `<Link to="${to}"> contains an invalid URL which will probably break when clicked - please update to a valid URL path.`);
+    }
+  }
+  return {
+    absoluteURL,
+    isExternal,
+    to
+  };
 }
+Object.getOwnPropertyNames(Object.prototype).sort().join("\0");
 
 // lib/router/router.ts
 var validMutationMethodsArr = ["POST", "PUT", "PATCH", "DELETE"];
@@ -1230,6 +1063,7 @@ var DataRouterContext = /*#__PURE__*/reactExports.createContext(null);
 DataRouterContext.displayName = "DataRouter";
 var DataRouterStateContext = /*#__PURE__*/reactExports.createContext(null);
 DataRouterStateContext.displayName = "DataRouterState";
+var RSCRouterContext = /*#__PURE__*/reactExports.createContext(false);
 var ViewTransitionContext = /*#__PURE__*/reactExports.createContext({
   isTransitioning: false
 });
@@ -1250,6 +1084,33 @@ var RouteContext = /*#__PURE__*/reactExports.createContext({
 RouteContext.displayName = "Route";
 var RouteErrorContext = /*#__PURE__*/reactExports.createContext(null);
 RouteErrorContext.displayName = "RouteError";
+
+// lib/errors.ts
+var ERROR_DIGEST_BASE = "REACT_ROUTER_ERROR";
+var ERROR_DIGEST_REDIRECT = "REDIRECT";
+var ERROR_DIGEST_ROUTE_ERROR_RESPONSE = "ROUTE_ERROR_RESPONSE";
+function decodeRedirectErrorDigest(digest) {
+  if (digest.startsWith(`${ERROR_DIGEST_BASE}:${ERROR_DIGEST_REDIRECT}:{`)) {
+    try {
+      let parsed = JSON.parse(digest.slice(28));
+      if (typeof parsed === "object" && parsed && typeof parsed.status === "number" && typeof parsed.statusText === "string" && typeof parsed.location === "string" && typeof parsed.reloadDocument === "boolean" && typeof parsed.replace === "boolean") {
+        return parsed;
+      }
+    } catch {}
+  }
+}
+function decodeRouteErrorResponseDigest(digest) {
+  if (digest.startsWith(`${ERROR_DIGEST_BASE}:${ERROR_DIGEST_ROUTE_ERROR_RESPONSE}:{`)) {
+    try {
+      let parsed = JSON.parse(digest.slice(40));
+      if (typeof parsed === "object" && parsed && typeof parsed.status === "number" && typeof parsed.statusText === "string") {
+        return new ErrorResponseImpl(parsed.status, parsed.statusText, parsed.data);
+      }
+    } catch {}
+  }
+}
+
+// lib/hooks.tsx
 function useHref(to, {
   relative
 } = {}) {
@@ -1340,12 +1201,9 @@ function useNavigateUnstable() {
 var OutletContext = /*#__PURE__*/reactExports.createContext(null);
 function useOutlet(context) {
   let outlet = reactExports.useContext(RouteContext).outlet;
-  if (outlet) {
-    return /* @__PURE__ */reactExports.createElement(OutletContext.Provider, {
-      value: context
-    }, outlet);
-  }
-  return outlet;
+  return reactExports.useMemo(() => outlet && /* @__PURE__ */reactExports.createElement(OutletContext.Provider, {
+    value: context
+  }, outlet), [outlet, context]);
 }
 function useResolvedPath(to, {
   relative
@@ -1362,7 +1220,7 @@ function useResolvedPath(to, {
 function useRoutes(routes, locationArg) {
   return useRoutesImpl(routes, locationArg);
 }
-function useRoutesImpl(routes, locationArg, dataRouterState, future) {
+function useRoutesImpl(routes, locationArg, dataRouterOpts) {
   invariant(useInRouterContext(),
   // TODO: This error is probably because they somehow have 2 versions of the
   // router loaded. We can help them understand how to avoid that.
@@ -1410,12 +1268,18 @@ Please change the parent <Route path="${parentPath}"> to <Route path="${parentPa
   let renderedMatches = _renderMatches(matches && matches.map(match => Object.assign({}, match, {
     params: Object.assign({}, parentParams, match.params),
     pathname: joinPaths([parentPathnameBase,
-    // Re-encode pathnames that were decoded inside matchRoutes
-    navigator.encodeLocation ? navigator.encodeLocation(match.pathname).pathname : match.pathname]),
+    // Re-encode pathnames that were decoded inside matchRoutes.
+    // Pre-encode `?` and `#` ahead of `encodeLocation` because it uses
+    // `new URL()` internally and we need to prevent it from treating
+    // them as separators
+    navigator.encodeLocation ? navigator.encodeLocation(match.pathname.replace(/\?/g, "%3F").replace(/#/g, "%23")).pathname : match.pathname]),
     pathnameBase: match.pathnameBase === "/" ? parentPathnameBase : joinPaths([parentPathnameBase,
     // Re-encode pathnames that were decoded inside matchRoutes
-    navigator.encodeLocation ? navigator.encodeLocation(match.pathnameBase).pathname : match.pathnameBase])
-  })), parentMatches, dataRouterState, future);
+    // Pre-encode `?` and `#` ahead of `encodeLocation` because it uses
+    // `new URL()` internally and we need to prevent it from treating
+    // them as separators
+    navigator.encodeLocation ? navigator.encodeLocation(match.pathnameBase.replace(/\?/g, "%3F").replace(/#/g, "%23")).pathname : match.pathnameBase])
+  })), parentMatches, dataRouterOpts);
   if (locationArg && renderedMatches) {
     return /* @__PURE__ */reactExports.createElement(LocationContext.Provider, {
       value: {
@@ -1425,6 +1289,7 @@ Please change the parent <Route path="${parentPath}"> to <Route path="${parentPa
           hash: "",
           state: null,
           key: "default",
+          unstable_mask: void 0,
           ...location
         },
         navigationType: "POP" /* Pop */
@@ -1433,37 +1298,6 @@ Please change the parent <Route path="${parentPath}"> to <Route path="${parentPa
   }
   return renderedMatches;
 }
-function DefaultErrorComponent() {
-  let error = useRouteError();
-  let message = isRouteErrorResponse(error) ? `${error.status} ${error.statusText}` : error instanceof Error ? error.message : JSON.stringify(error);
-  let stack = error instanceof Error ? error.stack : null;
-  let lightgrey = "rgba(200,200,200, 0.5)";
-  let preStyles = {
-    padding: "0.5rem",
-    backgroundColor: lightgrey
-  };
-  let codeStyles = {
-    padding: "2px 4px",
-    backgroundColor: lightgrey
-  };
-  let devInfo = null;
-  {
-    console.error("Error handled by React Router default ErrorBoundary:", error);
-    devInfo = /* @__PURE__ */reactExports.createElement(reactExports.Fragment, null, /* @__PURE__ */reactExports.createElement("p", null, "\u{1F4BF} Hey developer \u{1F44B}"), /* @__PURE__ */reactExports.createElement("p", null, "You can provide a way better UX than this when your app throws errors by providing your own ", /* @__PURE__ */reactExports.createElement("code", {
-      style: codeStyles
-    }, "ErrorBoundary"), " or", " ", /* @__PURE__ */reactExports.createElement("code", {
-      style: codeStyles
-    }, "errorElement"), " prop on your route."));
-  }
-  return /* @__PURE__ */reactExports.createElement(reactExports.Fragment, null, /* @__PURE__ */reactExports.createElement("h2", null, "Unexpected Application Error!"), /* @__PURE__ */reactExports.createElement("h3", {
-    style: {
-      fontStyle: "italic"
-    }
-  }, message), stack ? /* @__PURE__ */reactExports.createElement("pre", {
-    style: preStyles
-  }, stack) : null, devInfo);
-}
-var defaultErrorElement = /* @__PURE__ */reactExports.createElement(DefaultErrorComponent, null);
 var RenderErrorBoundary = class extends reactExports.Component {
   constructor(props) {
     super(props);
@@ -1493,17 +1327,66 @@ var RenderErrorBoundary = class extends reactExports.Component {
     };
   }
   componentDidCatch(error, errorInfo) {
-    console.error("React Router caught the following error during render", error, errorInfo);
+    if (this.props.onError) {
+      this.props.onError(error, errorInfo);
+    } else {
+      console.error("React Router caught the following error during render", error);
+    }
   }
   render() {
-    return this.state.error !== void 0 ? /* @__PURE__ */reactExports.createElement(RouteContext.Provider, {
+    let error = this.state.error;
+    if (this.context && typeof error === "object" && error && "digest" in error && typeof error.digest === "string") {
+      const decoded = decodeRouteErrorResponseDigest(error.digest);
+      if (decoded) error = decoded;
+    }
+    let result = error !== void 0 ? /* @__PURE__ */reactExports.createElement(RouteContext.Provider, {
       value: this.props.routeContext
     }, /* @__PURE__ */reactExports.createElement(RouteErrorContext.Provider, {
-      value: this.state.error,
+      value: error,
       children: this.props.component
     })) : this.props.children;
+    if (this.context) {
+      return /* @__PURE__ */reactExports.createElement(RSCErrorHandler, {
+        error
+      }, result);
+    }
+    return result;
   }
 };
+RenderErrorBoundary.contextType = RSCRouterContext;
+var errorRedirectHandledMap = /* @__PURE__ */new WeakMap();
+function RSCErrorHandler({
+  children,
+  error
+}) {
+  let {
+    basename
+  } = reactExports.useContext(NavigationContext);
+  if (typeof error === "object" && error && "digest" in error && typeof error.digest === "string") {
+    let redirect2 = decodeRedirectErrorDigest(error.digest);
+    if (redirect2) {
+      let existingRedirect = errorRedirectHandledMap.get(error);
+      if (existingRedirect) throw existingRedirect;
+      let parsed = parseToInfo(redirect2.location, basename);
+      if (isBrowser && !errorRedirectHandledMap.get(error)) {
+        if (parsed.isExternal || redirect2.reloadDocument) {
+          window.location.href = parsed.absoluteURL || parsed.to;
+        } else {
+          const redirectPromise = Promise.resolve().then(() => window.__reactRouterDataRouter.navigate(parsed.to, {
+            replace: redirect2.replace
+          }));
+          errorRedirectHandledMap.set(error, redirectPromise);
+          throw redirectPromise;
+        }
+      }
+      return /* @__PURE__ */reactExports.createElement("meta", {
+        httpEquiv: "refresh",
+        content: `0;url=${parsed.absoluteURL || parsed.to}`
+      });
+    }
+  }
+  return children;
+}
 function RenderedRoute({
   routeContext,
   match,
@@ -1517,79 +1400,19 @@ function RenderedRoute({
     value: routeContext
   }, children);
 }
-function _renderMatches(matches, parentMatches = [], dataRouterState = null, future = null) {
+function _renderMatches(matches, parentMatches = [], dataRouterOpts) {
+  let dataRouterState = dataRouterOpts?.state;
   if (matches == null) {
-    if (!dataRouterState) {
-      return null;
-    }
-    if (dataRouterState.errors) {
-      matches = dataRouterState.matches;
-    } else if (parentMatches.length === 0 && !dataRouterState.initialized && dataRouterState.matches.length > 0) {
-      matches = dataRouterState.matches;
-    } else {
+    {
       return null;
     }
   }
   let renderedMatches = matches;
-  let errors = dataRouterState?.errors;
-  if (errors != null) {
-    let errorIndex = renderedMatches.findIndex(m => m.route.id && errors?.[m.route.id] !== void 0);
-    invariant(errorIndex >= 0, `Could not find a matching route for errors on route IDs: ${Object.keys(errors).join(",")}`);
-    renderedMatches = renderedMatches.slice(0, Math.min(renderedMatches.length, errorIndex + 1));
-  }
-  let renderFallback = false;
-  let fallbackIndex = -1;
-  if (dataRouterState) {
-    for (let i = 0; i < renderedMatches.length; i++) {
-      let match = renderedMatches[i];
-      if (match.route.HydrateFallback || match.route.hydrateFallbackElement) {
-        fallbackIndex = i;
-      }
-      if (match.route.id) {
-        let {
-          loaderData,
-          errors: errors2
-        } = dataRouterState;
-        let needsToRunLoader = match.route.loader && !loaderData.hasOwnProperty(match.route.id) && (!errors2 || errors2[match.route.id] === void 0);
-        if (match.route.lazy || needsToRunLoader) {
-          renderFallback = true;
-          if (fallbackIndex >= 0) {
-            renderedMatches = renderedMatches.slice(0, fallbackIndex + 1);
-          } else {
-            renderedMatches = [renderedMatches[0]];
-          }
-          break;
-        }
-      }
-    }
-  }
   return renderedMatches.reduceRight((outlet, match, index) => {
-    let error;
-    let shouldRenderHydrateFallback = false;
-    let errorElement = null;
-    let hydrateFallbackElement = null;
-    if (dataRouterState) {
-      error = errors && match.route.id ? errors[match.route.id] : void 0;
-      errorElement = match.route.errorElement || defaultErrorElement;
-      if (renderFallback) {
-        if (fallbackIndex < 0 && index === 0) {
-          warningOnce("route-fallback", false, "No `HydrateFallback` element provided to render during initial hydration");
-          shouldRenderHydrateFallback = true;
-          hydrateFallbackElement = null;
-        } else if (fallbackIndex === index) {
-          shouldRenderHydrateFallback = true;
-          hydrateFallbackElement = match.route.hydrateFallbackElement || null;
-        }
-      }
-    }
     let matches2 = parentMatches.concat(renderedMatches.slice(0, index + 1));
     let getChildren = () => {
       let children;
-      if (error) {
-        children = errorElement;
-      } else if (shouldRenderHydrateFallback) {
-        children = hydrateFallbackElement;
-      } else if (match.route.Component) {
+      if (match.route.Component) {
         children = /* @__PURE__ */reactExports.createElement(match.route.Component, null);
       } else if (match.route.element) {
         children = match.route.element;
@@ -1606,18 +1429,7 @@ function _renderMatches(matches, parentMatches = [], dataRouterState = null, fut
         children
       });
     };
-    return dataRouterState && (match.route.ErrorBoundary || match.route.errorElement || index === 0) ? /* @__PURE__ */reactExports.createElement(RenderErrorBoundary, {
-      location: dataRouterState.location,
-      revalidation: dataRouterState.revalidation,
-      component: errorElement,
-      error,
-      children: getChildren(),
-      routeContext: {
-        outlet: null,
-        matches: matches2,
-        isDataRoute: true
-      }
-    }) : getChildren();
+    return getChildren();
   }, null);
 }
 function getDataRouterConsoleError(hookName) {
@@ -1627,11 +1439,6 @@ function useDataRouterContext(hookName) {
   let ctx = reactExports.useContext(DataRouterContext);
   invariant(ctx, getDataRouterConsoleError(hookName));
   return ctx;
-}
-function useDataRouterState(hookName) {
-  let state = reactExports.useContext(DataRouterStateContext);
-  invariant(state, getDataRouterConsoleError(hookName));
-  return state;
 }
 function useRouteContext(hookName) {
   let route = reactExports.useContext(RouteContext);
@@ -1647,15 +1454,6 @@ function useCurrentRouteId(hookName) {
 function useRouteId() {
   return useCurrentRouteId("useRouteId" /* UseRouteId */);
 }
-function useRouteError() {
-  let error = reactExports.useContext(RouteErrorContext);
-  let state = useDataRouterState("useRouteError" /* UseRouteError */);
-  let routeId = useCurrentRouteId("useRouteError" /* UseRouteError */);
-  if (error !== void 0) {
-    return error;
-  }
-  return state.errors?.[routeId];
-}
 function useNavigateStable() {
   let {
     router
@@ -1669,7 +1467,7 @@ function useNavigateStable() {
     warning(activeRef.current, navigateEffectWarning);
     if (!activeRef.current) return;
     if (typeof to === "number") {
-      router.navigate(to);
+      await router.navigate(to);
     } else {
       await router.navigate(to, {
         fromRouteId: id,
@@ -1689,7 +1487,7 @@ function warningOnce(key, cond, message) {
 function Outlet(props) {
   return useOutlet(props.context);
 }
-function Route(_props) {
+function Route(props) {
   invariant(false, `A <Route> is only ever to be used as the child of <Routes> element, never rendered directly. Please wrap your <Route> in a <Routes>.`);
 }
 function Router({
@@ -1698,7 +1496,8 @@ function Router({
   location: locationProp,
   navigationType = "POP" /* Pop */,
   navigator,
-  static: staticProp = false
+  static: staticProp = false,
+  unstable_useTransitions
 }) {
   invariant(!useInRouterContext(), `You cannot render a <Router> inside another <Router>. You should never have more than one in your app.`);
   let basename = basenameProp.replace(/^\/*/, "/");
@@ -1706,8 +1505,9 @@ function Router({
     basename,
     navigator,
     static: staticProp,
+    unstable_useTransitions,
     future: {}
-  }), [basename, navigator, staticProp]);
+  }), [basename, navigator, staticProp, unstable_useTransitions]);
   if (typeof locationProp === "string") {
     locationProp = parsePath(locationProp);
   }
@@ -1716,7 +1516,8 @@ function Router({
     search = "",
     hash = "",
     state = null,
-    key = "default"
+    key = "default",
+    unstable_mask
   } = locationProp;
   let locationContext = reactExports.useMemo(() => {
     let trailingPathname = stripBasename(pathname, basename);
@@ -1729,11 +1530,12 @@ function Router({
         search,
         hash,
         state,
-        key
+        key,
+        unstable_mask
       },
       navigationType
     };
-  }, [basename, pathname, search, hash, state, key, navigationType]);
+  }, [basename, pathname, search, hash, state, key, navigationType, unstable_mask]);
   warning(locationContext != null, `<Router basename="${basename}"> is not able to match the URL "${pathname}${search}${hash}" because it does not start with the basename, so the <Router> won't render anything.`);
   if (locationContext == null) {
     return null;
@@ -1771,6 +1573,7 @@ function createRoutesFromChildren(children, parentPath = []) {
       Component: element.props.Component,
       index: element.props.index,
       path: element.props.path,
+      middleware: element.props.middleware,
       loader: element.props.loader,
       action: element.props.action,
       hydrateFallbackElement: element.props.hydrateFallbackElement,
@@ -1794,7 +1597,7 @@ function createRoutesFromChildren(children, parentPath = []) {
 var defaultMethod = "get";
 var defaultEncType = "application/x-www-form-urlencoded";
 function isHtmlElement(object) {
-  return object != null && typeof object.tagName === "string";
+  return typeof HTMLElement !== "undefined" && object instanceof HTMLElement;
 }
 function isButtonElement(object) {
   return isHtmlElement(object) && object.tagName.toLowerCase() === "button";
@@ -1893,12 +1696,35 @@ function getFormSubmissionInfo(target, basename) {
     body
   };
 }
+Object.getOwnPropertyNames(Object.prototype).sort().join("\0");
 
 // lib/dom/ssr/invariant.ts
 function invariant2(value, message) {
   if (value === false || value === null || typeof value === "undefined") {
     throw new Error(message);
   }
+}
+function singleFetchUrl(reqUrl, basename, trailingSlashAware, extension) {
+  let url = typeof reqUrl === "string" ? new URL(reqUrl,
+  // This can be called during the SSR flow via PrefetchPageLinksImpl so
+  // don't assume window is available
+  typeof window === "undefined" ? "server://singlefetch/" : window.location.origin) : reqUrl;
+  if (trailingSlashAware) {
+    if (url.pathname.endsWith("/")) {
+      url.pathname = `${url.pathname}_.${extension}`;
+    } else {
+      url.pathname = `${url.pathname}.${extension}`;
+    }
+  } else {
+    if (url.pathname === "/") {
+      url.pathname = `_root.${extension}`;
+    } else if (basename && stripBasename(url.pathname, basename) === "/") {
+      url.pathname = `${basename.replace(/\/$/, "")}/_root.${extension}`;
+    } else {
+      url.pathname = `${url.pathname.replace(/\/$/, "")}.${extension}`;
+    }
+  }
+  return url;
 }
 
 // lib/dom/ssr/routeModules.ts
@@ -2042,22 +1868,6 @@ function dedupeLinkDescriptors(descriptors, preloads) {
     return deduped;
   }, []);
 }
-Object.getOwnPropertyNames(Object.prototype).sort().join("\0");
-var NO_BODY_STATUS_CODES = /* @__PURE__ */new Set([100, 101, 204, 205]);
-function singleFetchUrl(reqUrl, basename) {
-  let url = typeof reqUrl === "string" ? new URL(reqUrl,
-  // This can be called during the SSR flow via PrefetchPageLinksImpl so
-  // don't assume window is available
-  typeof window === "undefined" ? "server://singlefetch/" : window.location.origin) : reqUrl;
-  if (url.pathname === "/") {
-    url.pathname = "_root.data";
-  } else if (basename && stripBasename(url.pathname, basename) === "/") {
-    url.pathname = `${basename.replace(/\/$/, "")}/_root.data`;
-  } else {
-    url.pathname = `${url.pathname.replace(/\/$/, "")}.data`;
-  }
-  return url;
-}
 
 // lib/dom/ssr/components.tsx
 function useDataRouterContext2() {
@@ -2149,7 +1959,7 @@ function composeEventHandlers(theirHandler, ourHandler) {
 }
 function PrefetchPageLinks({
   page,
-  ...dataLinkProps
+  ...linkProps
 }) {
   let {
     router
@@ -2161,7 +1971,7 @@ function PrefetchPageLinks({
   return /* @__PURE__ */reactExports.createElement(PrefetchPageLinksImpl, {
     page,
     matches,
-    ...dataLinkProps
+    ...linkProps
   });
 }
 function useKeyedPrefetchLinks(matches) {
@@ -2190,6 +2000,7 @@ function PrefetchPageLinksImpl({
 }) {
   let location = useLocation();
   let {
+    future,
     manifest,
     routeModules
   } = useFrameworkContext();
@@ -2224,24 +2035,24 @@ function PrefetchPageLinksImpl({
     if (routesParams.size === 0) {
       return [];
     }
-    let url = singleFetchUrl(page, basename);
+    let url = singleFetchUrl(page, basename, future.unstable_trailingSlashAwareDataRequests, "data");
     if (foundOptOutRoute && routesParams.size > 0) {
       url.searchParams.set("_routes", nextMatches.filter(m => routesParams.has(m.route.id)).map(m => m.route.id).join(","));
     }
     return [url.pathname + url.search];
-  }, [basename, loaderData, location, manifest, newMatchesForData, nextMatches, page, routeModules]);
+  }, [basename, future.unstable_trailingSlashAwareDataRequests, loaderData, location, manifest, newMatchesForData, nextMatches, page, routeModules]);
   let moduleHrefs = reactExports.useMemo(() => getModuleLinkHrefs(newMatchesForAssets, manifest), [newMatchesForAssets, manifest]);
   let keyedPrefetchLinks = useKeyedPrefetchLinks(newMatchesForAssets);
-  return /* @__PURE__ */reactExports.createElement(reactExports.Fragment, null, dataHrefs.map(href2 => /* @__PURE__ */reactExports.createElement("link", {
-    key: href2,
+  return /* @__PURE__ */reactExports.createElement(reactExports.Fragment, null, dataHrefs.map(href => /* @__PURE__ */reactExports.createElement("link", {
+    key: href,
     rel: "prefetch",
     as: "fetch",
-    href: href2,
+    href,
     ...linkProps
-  })), moduleHrefs.map(href2 => /* @__PURE__ */reactExports.createElement("link", {
-    key: href2,
+  })), moduleHrefs.map(href => /* @__PURE__ */reactExports.createElement("link", {
+    key: href,
     rel: "modulepreload",
-    href: href2,
+    href,
     ...linkProps
   })), keyedPrefetchLinks.map(({
     key,
@@ -2252,7 +2063,9 @@ function PrefetchPageLinksImpl({
   /* @__PURE__ */
   reactExports.createElement("link", {
     key,
-    ...link
+    nonce: linkProps.nonce,
+    ...link,
+    crossOrigin: link.crossOrigin ?? linkProps.crossOrigin
   })));
 }
 function mergeRefs(...refs) {
@@ -2266,17 +2079,18 @@ function mergeRefs(...refs) {
     });
   };
 }
-
-// lib/dom/lib.tsx
-var isBrowser = typeof window !== "undefined" && typeof window.document !== "undefined" && typeof window.document.createElement !== "undefined";
+var isBrowser2 = typeof window !== "undefined" && typeof window.document !== "undefined" && typeof window.document.createElement !== "undefined";
 try {
-  if (isBrowser) {
-    window.__reactRouterVersion = "7.6.1";
+  if (isBrowser2) {
+    window.__reactRouterVersion =
+    // @ts-expect-error
+    "7.13.1";
   }
 } catch (e) {}
 function HashRouter({
   basename,
   children,
+  unstable_useTransitions,
   window: window2
 }) {
   let historyRef = reactExports.useRef();
@@ -2292,15 +2106,20 @@ function HashRouter({
     location: history.location
   });
   let setState = reactExports.useCallback(newState => {
-    reactExports.startTransition(() => setStateImpl(newState));
-  }, [setStateImpl]);
+    if (unstable_useTransitions === false) {
+      setStateImpl(newState);
+    } else {
+      reactExports.startTransition(() => setStateImpl(newState));
+    }
+  }, [unstable_useTransitions]);
   reactExports.useLayoutEffect(() => history.listen(setState), [history, setState]);
   return /* @__PURE__ */reactExports.createElement(Router, {
     basename,
     children,
     location: state.location,
     navigationType: state.action,
-    navigator: history
+    navigator: history,
+    unstable_useTransitions
   });
 }
 var ABSOLUTE_URL_REGEX2 = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
@@ -2311,47 +2130,46 @@ var Link$1 = /*#__PURE__*/reactExports.forwardRef(function LinkWithRef({
   relative,
   reloadDocument,
   replace: replace2,
+  unstable_mask,
   state,
   target,
   to,
   preventScrollReset,
   viewTransition,
+  unstable_defaultShouldRevalidate,
   ...rest
 }, forwardedRef) {
   let {
-    basename
+    basename,
+    navigator,
+    unstable_useTransitions
   } = reactExports.useContext(NavigationContext);
   let isAbsolute = typeof to === "string" && ABSOLUTE_URL_REGEX2.test(to);
-  let absoluteHref;
-  let isExternal = false;
-  if (typeof to === "string" && isAbsolute) {
-    absoluteHref = to;
-    if (isBrowser) {
-      try {
-        let currentUrl = new URL(window.location.href);
-        let targetUrl = to.startsWith("//") ? new URL(currentUrl.protocol + to) : new URL(to);
-        let path = stripBasename(targetUrl.pathname, basename);
-        if (targetUrl.origin === currentUrl.origin && path != null) {
-          to = path + targetUrl.search + targetUrl.hash;
-        } else {
-          isExternal = true;
-        }
-      } catch (e) {
-        warning(false, `<Link to="${to}"> contains an invalid URL which will probably break when clicked - please update to a valid URL path.`);
-      }
-    }
-  }
-  let href2 = useHref(to, {
+  let parsed = parseToInfo(to, basename);
+  to = parsed.to;
+  let href = useHref(to, {
     relative
   });
+  let location = useLocation();
+  let maskedHref = null;
+  if (unstable_mask) {
+    let resolved = resolveTo(unstable_mask, [], location.unstable_mask ? location.unstable_mask.pathname : "/", true);
+    if (basename !== "/") {
+      resolved.pathname = resolved.pathname === "/" ? basename : joinPaths([basename, resolved.pathname]);
+    }
+    maskedHref = navigator.createHref(resolved);
+  }
   let [shouldPrefetch, prefetchRef, prefetchHandlers] = usePrefetchBehavior(prefetch, rest);
   let internalOnClick = useLinkClickHandler(to, {
     replace: replace2,
+    unstable_mask,
     state,
     target,
     preventScrollReset,
     relative,
-    viewTransition
+    viewTransition,
+    unstable_defaultShouldRevalidate,
+    unstable_useTransitions
   });
   function handleClick(event) {
     if (onClick) onClick(event);
@@ -2359,20 +2177,21 @@ var Link$1 = /*#__PURE__*/reactExports.forwardRef(function LinkWithRef({
       internalOnClick(event);
     }
   }
+  let isSpaLink = !(parsed.isExternal || reloadDocument);
   let link =
   // eslint-disable-next-line jsx-a11y/anchor-has-content
   /* @__PURE__ */
   reactExports.createElement("a", {
     ...rest,
     ...prefetchHandlers,
-    href: absoluteHref || href2,
-    onClick: isExternal || reloadDocument ? onClick : handleClick,
+    href: (isSpaLink ? maskedHref : void 0) || parsed.absoluteURL || href,
+    onClick: isSpaLink ? handleClick : onClick,
     ref: mergeRefs(forwardedRef, prefetchRef),
     target,
     "data-discover": !isAbsolute && discover === "render" ? "true" : void 0
   });
   return shouldPrefetch && !isAbsolute ? /* @__PURE__ */reactExports.createElement(reactExports.Fragment, null, link, /* @__PURE__ */reactExports.createElement(PrefetchPageLinks, {
-    page: href2
+    page: href
   })) : link;
 });
 Link$1.displayName = "Link";
@@ -2451,8 +2270,12 @@ var Form = /*#__PURE__*/reactExports.forwardRef(({
   relative,
   preventScrollReset,
   viewTransition,
+  unstable_defaultShouldRevalidate,
   ...props
 }, forwardedRef) => {
+  let {
+    unstable_useTransitions
+  } = reactExports.useContext(NavigationContext);
   let submit = useSubmit();
   let formAction = useFormAction(action, {
     relative
@@ -2465,7 +2288,7 @@ var Form = /*#__PURE__*/reactExports.forwardRef(({
     event.preventDefault();
     let submitter = event.nativeEvent.submitter;
     let submitMethod = submitter?.getAttribute("formmethod") || method;
-    submit(submitter || event.currentTarget, {
+    let doSubmit = () => submit(submitter || event.currentTarget, {
       fetcherKey,
       method: submitMethod,
       navigate,
@@ -2473,8 +2296,14 @@ var Form = /*#__PURE__*/reactExports.forwardRef(({
       state,
       relative,
       preventScrollReset,
-      viewTransition
+      viewTransition,
+      unstable_defaultShouldRevalidate
     });
+    if (unstable_useTransitions && navigate !== false) {
+      reactExports.startTransition(() => doSubmit());
+    } else {
+      doSubmit();
+    }
   };
   return /* @__PURE__ */reactExports.createElement("form", {
     ref: forwardedRef,
@@ -2497,10 +2326,13 @@ function useDataRouterContext3(hookName) {
 function useLinkClickHandler(to, {
   target,
   replace: replaceProp,
+  unstable_mask,
   state,
   preventScrollReset,
   relative,
-  viewTransition
+  viewTransition,
+  unstable_defaultShouldRevalidate,
+  unstable_useTransitions
 } = {}) {
   let navigate = useNavigate();
   let location = useLocation();
@@ -2511,15 +2343,22 @@ function useLinkClickHandler(to, {
     if (shouldProcessLinkClick(event, target)) {
       event.preventDefault();
       let replace2 = replaceProp !== void 0 ? replaceProp : createPath(location) === createPath(path);
-      navigate(to, {
+      let doNavigate = () => navigate(to, {
         replace: replace2,
+        unstable_mask,
         state,
         preventScrollReset,
         relative,
-        viewTransition
+        viewTransition,
+        unstable_defaultShouldRevalidate
       });
+      if (unstable_useTransitions) {
+        reactExports.startTransition(() => doNavigate());
+      } else {
+        doNavigate();
+      }
     }
-  }, [location, navigate, path, replaceProp, state, target, to, preventScrollReset, relative, viewTransition]);
+  }, [location, navigate, path, replaceProp, unstable_mask, state, target, to, preventScrollReset, relative, viewTransition, unstable_defaultShouldRevalidate, unstable_useTransitions]);
 }
 var fetcherId = 0;
 var getUniqueFetcherId = () => `__${String(++fetcherId)}__`;
@@ -2531,6 +2370,8 @@ function useSubmit() {
     basename
   } = reactExports.useContext(NavigationContext);
   let currentRouteId = useRouteId();
+  let routerFetch = router.fetch;
+  let routerNavigate = router.navigate;
   return reactExports.useCallback(async (target, options = {}) => {
     let {
       action,
@@ -2541,7 +2382,8 @@ function useSubmit() {
     } = getFormSubmissionInfo(target, basename);
     if (options.navigate === false) {
       let key = options.fetcherKey || getUniqueFetcherId();
-      await router.fetch(key, currentRouteId, options.action || action, {
+      await routerFetch(key, currentRouteId, options.action || action, {
+        unstable_defaultShouldRevalidate: options.unstable_defaultShouldRevalidate,
         preventScrollReset: options.preventScrollReset,
         formData,
         body,
@@ -2550,7 +2392,8 @@ function useSubmit() {
         flushSync: options.flushSync
       });
     } else {
-      await router.navigate(options.action || action, {
+      await routerNavigate(options.action || action, {
+        unstable_defaultShouldRevalidate: options.unstable_defaultShouldRevalidate,
         preventScrollReset: options.preventScrollReset,
         formData,
         body,
@@ -2563,7 +2406,7 @@ function useSubmit() {
         viewTransition: options.viewTransition
       });
     }
-  }, [router, basename, currentRouteId]);
+  }, [routerFetch, routerNavigate, basename, currentRouteId]);
 }
 function useFormAction(action, {
   relative
@@ -2600,14 +2443,16 @@ function useFormAction(action, {
   }
   return createPath(path);
 }
-function useViewTransitionState(to, opts = {}) {
+function useViewTransitionState(to, {
+  relative
+} = {}) {
   let vtContext = reactExports.useContext(ViewTransitionContext);
   invariant(vtContext != null, "`useViewTransitionState` must be used within `react-router-dom`'s `RouterProvider`.  Did you accidentally import `RouterProvider` from `react-router`?");
   let {
     basename
   } = useDataRouterContext3("useViewTransitionState" /* useViewTransitionState */);
   let path = useResolvedPath(to, {
-    relative: opts.relative
+    relative
   });
   if (!vtContext.isTransitioning) {
     return false;
@@ -2616,9 +2461,6 @@ function useViewTransitionState(to, opts = {}) {
   let nextPath = stripBasename(vtContext.nextLocation.pathname, basename) || vtContext.nextLocation.pathname;
   return matchPath(path.pathname, nextPath) != null || matchPath(path.pathname, currentPath) != null;
 }
-
-// lib/server-runtime/single-fetch.ts
-/* @__PURE__ */new Set([...NO_BODY_STATUS_CODES, 304]);
 
 var reactDom = {exports: {}};
 
@@ -2843,7 +2685,7 @@ function _v4(options, buf, offset) {
   return unsafeStringify(rnds);
 }
 function v4(options, buf, offset) {
-  if (native.randomUUID && true && true) {
+  if (native.randomUUID && true && !options) {
     return native.randomUUID();
   }
   return _v4(options);
@@ -6344,20 +6186,20 @@ function Home() {
  * SPDX-License-Identifier: BSD-3-Clause
  */
 const t$4 = globalThis,
-  e$b = t$4.ShadowRoot && (void 0 === t$4.ShadyCSS || t$4.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype,
-  s$2 = Symbol(),
-  o$c = new WeakMap();
+  e$a = t$4.ShadowRoot && (void 0 === t$4.ShadyCSS || t$4.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype,
+  s$3 = Symbol(),
+  o$d = new WeakMap();
 let n$9 = class n {
   constructor(t, e, o) {
-    if (this._$cssResult$ = true, o !== s$2) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
+    if (this._$cssResult$ = true, o !== s$3) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
     this.cssText = t, this.t = e;
   }
   get styleSheet() {
     let t = this.o;
     const s = this.t;
-    if (e$b && void 0 === t) {
+    if (e$a && void 0 === t) {
       const e = void 0 !== s && 1 === s.length;
-      e && (t = o$c.get(s)), void 0 === t && ((this.o = t = new CSSStyleSheet()).replaceSync(this.cssText), e && o$c.set(s, t));
+      e && (t = o$d.get(s)), void 0 === t && ((this.o = t = new CSSStyleSheet()).replaceSync(this.cssText), e && o$d.set(s, t));
     }
     return t;
   }
@@ -6365,23 +6207,23 @@ let n$9 = class n {
     return this.cssText;
   }
 };
-const r$8 = t => new n$9("string" == typeof t ? t : t + "", void 0, s$2),
+const r$8 = t => new n$9("string" == typeof t ? t : t + "", void 0, s$3),
   i$7 = (t, ...e) => {
     const o = 1 === t.length ? t[0] : e.reduce((e, s, o) => e + (t => {
       if (true === t._$cssResult$) return t.cssText;
       if ("number" == typeof t) return t;
       throw Error("Value passed to 'css' function must be a 'css' function result: " + t + ". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.");
     })(s) + t[o + 1], t[0]);
-    return new n$9(o, t, s$2);
+    return new n$9(o, t, s$3);
   },
   S$1 = (s, o) => {
-    if (e$b) s.adoptedStyleSheets = o.map(t => t instanceof CSSStyleSheet ? t : t.styleSheet);else for (const e of o) {
+    if (e$a) s.adoptedStyleSheets = o.map(t => t instanceof CSSStyleSheet ? t : t.styleSheet);else for (const e of o) {
       const o = document.createElement("style"),
         n = t$4.litNonce;
       void 0 !== n && o.setAttribute("nonce", n), o.textContent = e.cssText, s.appendChild(o);
     }
   },
-  c$3 = e$b ? t => t : t => t instanceof CSSStyleSheet ? (t => {
+  c$3 = e$a ? t => t : t => t instanceof CSSStyleSheet ? (t => {
     let e = "";
     for (const s of t.cssRules) e += s.cssText;
     return r$8(e);
@@ -6394,22 +6236,22 @@ const r$8 = t => new n$9("string" == typeof t ? t : t + "", void 0, s$2),
  */
 const {
     is: i$6,
-    defineProperty: e$a,
-    getOwnPropertyDescriptor: r$7,
-    getOwnPropertyNames: h$3,
-    getOwnPropertySymbols: o$b,
+    defineProperty: e$9,
+    getOwnPropertyDescriptor: h$3,
+    getOwnPropertyNames: r$7,
+    getOwnPropertySymbols: o$c,
     getPrototypeOf: n$8
   } = Object,
   a$2 = globalThis,
   c$2 = a$2.trustedTypes,
-  l$3 = c$2 ? c$2.emptyScript : "",
-  p$1 = a$2.reactiveElementPolyfillSupport,
+  l$4 = c$2 ? c$2.emptyScript : "",
+  p$2 = a$2.reactiveElementPolyfillSupport,
   d$1 = (t, s) => t,
-  u$3 = {
+  u$2 = {
     toAttribute(t, s) {
       switch (s) {
         case Boolean:
-          t = t ? l$3 : null;
+          t = t ? l$4 : null;
           break;
         case Object:
         case Array:
@@ -6437,34 +6279,35 @@ const {
       return i;
     }
   },
-  f$3 = (t, s) => !i$6(t, s),
-  y$1 = {
+  f$2 = (t, s) => !i$6(t, s),
+  b$1 = {
     attribute: true,
     type: String,
-    converter: u$3,
+    converter: u$2,
     reflect: false,
-    hasChanged: f$3
+    useDefault: false,
+    hasChanged: f$2
   };
 Symbol.metadata ??= Symbol("metadata"), a$2.litPropertyMetadata ??= new WeakMap();
-class b extends HTMLElement {
+let y$1 = class y extends HTMLElement {
   static addInitializer(t) {
     this._$Ei(), (this.l ??= []).push(t);
   }
   static get observedAttributes() {
     return this.finalize(), this._$Eh && [...this._$Eh.keys()];
   }
-  static createProperty(t, s = y$1) {
-    if (s.state && (s.attribute = false), this._$Ei(), this.elementProperties.set(t, s), !s.noAccessor) {
+  static createProperty(t, s = b$1) {
+    if (s.state && (s.attribute = false), this._$Ei(), this.prototype.hasOwnProperty(t) && ((s = Object.create(s)).wrapped = true), this.elementProperties.set(t, s), !s.noAccessor) {
       const i = Symbol(),
-        r = this.getPropertyDescriptor(t, i, s);
-      void 0 !== r && e$a(this.prototype, t, r);
+        h = this.getPropertyDescriptor(t, i, s);
+      void 0 !== h && e$9(this.prototype, t, h);
     }
   }
   static getPropertyDescriptor(t, s, i) {
     const {
       get: e,
-      set: h
-    } = r$7(this.prototype, t) ?? {
+      set: r
+    } = h$3(this.prototype, t) ?? {
       get() {
         return this[s];
       },
@@ -6473,19 +6316,17 @@ class b extends HTMLElement {
       }
     };
     return {
-      get() {
-        return e?.call(this);
-      },
+      get: e,
       set(s) {
-        const r = e?.call(this);
-        h.call(this, s), this.requestUpdate(t, r, i);
+        const h = e?.call(this);
+        r?.call(this, s), this.requestUpdate(t, h, i);
       },
       configurable: true,
       enumerable: true
     };
   }
   static getPropertyOptions(t) {
-    return this.elementProperties.get(t) ?? y$1;
+    return this.elementProperties.get(t) ?? b$1;
   }
   static _$Ei() {
     if (this.hasOwnProperty(d$1("elementProperties"))) return;
@@ -6496,7 +6337,7 @@ class b extends HTMLElement {
     if (this.hasOwnProperty(d$1("finalized"))) return;
     if (this.finalized = true, this._$Ei(), this.hasOwnProperty(d$1("properties"))) {
       const t = this.properties,
-        s = [...h$3(t), ...o$b(t)];
+        s = [...r$7(t), ...o$c(t)];
       for (const i of s) this.createProperty(i, t[i]);
     }
     const t = this[Symbol.metadata];
@@ -6555,12 +6396,12 @@ class b extends HTMLElement {
   attributeChangedCallback(t, s, i) {
     this._$AK(t, i);
   }
-  _$EC(t, s) {
+  _$ET(t, s) {
     const i = this.constructor.elementProperties.get(t),
       e = this.constructor._$Eu(t, i);
     if (void 0 !== e && true === i.reflect) {
-      const r = (void 0 !== i.converter?.toAttribute ? i.converter : u$3).toAttribute(s, i.type);
-      this._$Em = t, null == r ? this.removeAttribute(e) : this.setAttribute(e, r), this._$Em = null;
+      const h = (void 0 !== i.converter?.toAttribute ? i.converter : u$2).toAttribute(s, i.type);
+      this._$Em = t, null == h ? this.removeAttribute(e) : this.setAttribute(e, h), this._$Em = null;
     }
   }
   _$AK(t, s) {
@@ -6568,23 +6409,30 @@ class b extends HTMLElement {
       e = i._$Eh.get(t);
     if (void 0 !== e && this._$Em !== e) {
       const t = i.getPropertyOptions(e),
-        r = "function" == typeof t.converter ? {
+        h = "function" == typeof t.converter ? {
           fromAttribute: t.converter
-        } : void 0 !== t.converter?.fromAttribute ? t.converter : u$3;
-      this._$Em = e, this[e] = r.fromAttribute(s, t.type), this._$Em = null;
+        } : void 0 !== t.converter?.fromAttribute ? t.converter : u$2;
+      this._$Em = e;
+      const r = h.fromAttribute(s, t.type);
+      this[e] = r ?? this._$Ej?.get(e) ?? r, this._$Em = null;
     }
   }
-  requestUpdate(t, s, i) {
+  requestUpdate(t, s, i, e = false, h) {
     if (void 0 !== t) {
-      if (i ??= this.constructor.getPropertyOptions(t), !(i.hasChanged ?? f$3)(this[t], s)) return;
-      this.P(t, s, i);
+      const r = this.constructor;
+      if (false === e && (h = this[t]), i ??= r.getPropertyOptions(t), !((i.hasChanged ?? f$2)(h, s) || i.useDefault && i.reflect && h === this._$Ej?.get(t) && !this.hasAttribute(r._$Eu(t, i)))) return;
+      this.C(t, s, i);
     }
-    false === this.isUpdatePending && (this._$ES = this._$ET());
+    false === this.isUpdatePending && (this._$ES = this._$EP());
   }
-  P(t, s, i) {
-    this._$AL.has(t) || this._$AL.set(t, s), true === i.reflect && this._$Em !== t && (this._$Ej ??= new Set()).add(t);
+  C(t, s, {
+    useDefault: i,
+    reflect: e,
+    wrapped: h
+  }, r) {
+    i && !(this._$Ej ??= new Map()).has(t) && (this._$Ej.set(t, r ?? s ?? this[t]), true !== h || void 0 !== r) || (this._$AL.has(t) || (this.hasUpdated || i || (s = void 0), this._$AL.set(t, s)), true === e && this._$Em !== t && (this._$Eq ??= new Set()).add(t));
   }
-  async _$ET() {
+  async _$EP() {
     this.isUpdatePending = true;
     try {
       await this._$ES;
@@ -6605,14 +6453,20 @@ class b extends HTMLElement {
         this._$Ep = void 0;
       }
       const t = this.constructor.elementProperties;
-      if (t.size > 0) for (const [s, i] of t) true !== i.wrapped || this._$AL.has(s) || void 0 === this[s] || this.P(s, this[s], i);
+      if (t.size > 0) for (const [s, i] of t) {
+        const {
+            wrapped: t
+          } = i,
+          e = this[s];
+        true !== t || this._$AL.has(s) || void 0 === e || this.C(s, void 0, i, e);
+      }
     }
     let t = false;
     const s = this._$AL;
     try {
-      t = this.shouldUpdate(s), t ? (this.willUpdate(s), this._$EO?.forEach(t => t.hostUpdate?.()), this.update(s)) : this._$EU();
+      t = this.shouldUpdate(s), t ? (this.willUpdate(s), this._$EO?.forEach(t => t.hostUpdate?.()), this.update(s)) : this._$EM();
     } catch (s) {
-      throw t = false, this._$EU(), s;
+      throw t = false, this._$EM(), s;
     }
     t && this._$AE(s);
   }
@@ -6620,7 +6474,7 @@ class b extends HTMLElement {
   _$AE(t) {
     this._$EO?.forEach(t => t.hostUpdated?.()), this.hasUpdated || (this.hasUpdated = true, this.firstUpdated(t)), this.updated(t);
   }
-  _$EU() {
+  _$EM() {
     this._$AL = new Map(), this.isUpdatePending = false;
   }
   get updateComplete() {
@@ -6633,16 +6487,16 @@ class b extends HTMLElement {
     return true;
   }
   update(t) {
-    this._$Ej &&= this._$Ej.forEach(t => this._$EC(t, this[t])), this._$EU();
+    this._$Eq &&= this._$Eq.forEach(t => this._$ET(t, this[t])), this._$EM();
   }
   updated(t) {}
   firstUpdated(t) {}
-}
-b.elementStyles = [], b.shadowRootOptions = {
+};
+y$1.elementStyles = [], y$1.shadowRootOptions = {
   mode: "open"
-}, b[d$1("elementProperties")] = new Map(), b[d$1("finalized")] = new Map(), p$1?.({
-  ReactiveElement: b
-}), (a$2.reactiveElementVersions ??= []).push("2.0.4");
+}, y$1[d$1("elementProperties")] = new Map(), y$1[d$1("finalized")] = new Map(), p$2?.({
+  ReactiveElement: y$1
+}), (a$2.reactiveElementVersions ??= []).push("2.1.2");
 
 /**
  * @license
@@ -6650,129 +6504,130 @@ b.elementStyles = [], b.shadowRootOptions = {
  * SPDX-License-Identifier: BSD-3-Clause
  */
 const t$3 = globalThis,
-  i$5 = t$3.trustedTypes,
-  s$1 = i$5 ? i$5.createPolicy("lit-html", {
+  i$5 = t => t,
+  s$2 = t$3.trustedTypes,
+  e$8 = s$2 ? s$2.createPolicy("lit-html", {
     createHTML: t => t
   }) : void 0,
-  e$9 = "$lit$",
-  h$2 = `lit$${Math.random().toFixed(9).slice(2)}$`,
-  o$a = "?" + h$2,
-  n$7 = `<${o$a}>`,
-  r$6 = document,
-  l$2 = () => r$6.createComment(""),
-  c$1 = t => null === t || "object" != typeof t && "function" != typeof t,
-  a$1 = Array.isArray,
-  u$2 = t => a$1(t) || "function" == typeof t?.[Symbol.iterator],
-  d = "[ \t\n\f\r]",
-  f$2 = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,
-  v = /-->/g,
-  _ = />/g,
-  m$1 = RegExp(`>|${d}(?:([^\\s"'>=/]+)(${d}*=${d}*(?:[^ \t\n\f\r"'\`<>=]|("|')|))|$)`, "g"),
-  p = /'/g,
-  g = /"/g,
-  $ = /^(?:script|style|textarea|title)$/i,
-  y = t => (i, ...s) => ({
+  h$2 = "$lit$",
+  o$b = `lit$${Math.random().toFixed(9).slice(2)}$`,
+  n$7 = "?" + o$b,
+  r$6 = `<${n$7}>`,
+  l$3 = document,
+  c$1 = () => l$3.createComment(""),
+  a$1 = t => null === t || "object" != typeof t && "function" != typeof t,
+  u$1 = Array.isArray,
+  d = t => u$1(t) || "function" == typeof t?.[Symbol.iterator],
+  f$1 = "[ \t\n\f\r]",
+  v = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,
+  _ = /-->/g,
+  m$1 = />/g,
+  p$1 = RegExp(`>|${f$1}(?:([^\\s"'>=/]+)(${f$1}*=${f$1}*(?:[^ \t\n\f\r"'\`<>=]|("|')|))|$)`, "g"),
+  g = /'/g,
+  $ = /"/g,
+  y = /^(?:script|style|textarea|title)$/i,
+  x = t => (i, ...s) => ({
     _$litType$: t,
     strings: i,
     values: s
   }),
-  x = y(1),
-  T = Symbol.for("lit-noChange"),
-  E = Symbol.for("lit-nothing"),
-  A = new WeakMap(),
-  C = r$6.createTreeWalker(r$6, 129);
-function P(t, i) {
-  if (!a$1(t) || !t.hasOwnProperty("raw")) throw Error("invalid template strings array");
-  return void 0 !== s$1 ? s$1.createHTML(i) : i;
+  b = x(1),
+  E = Symbol.for("lit-noChange"),
+  A = Symbol.for("lit-nothing"),
+  C = new WeakMap(),
+  P = l$3.createTreeWalker(l$3, 129);
+function V(t, i) {
+  if (!u$1(t) || !t.hasOwnProperty("raw")) throw Error("invalid template strings array");
+  return void 0 !== e$8 ? e$8.createHTML(i) : i;
 }
-const V = (t, i) => {
+const N = (t, i) => {
   const s = t.length - 1,
-    o = [];
-  let r,
+    e = [];
+  let n,
     l = 2 === i ? "<svg>" : 3 === i ? "<math>" : "",
-    c = f$2;
+    c = v;
   for (let i = 0; i < s; i++) {
     const s = t[i];
     let a,
       u,
       d = -1,
-      y = 0;
-    for (; y < s.length && (c.lastIndex = y, u = c.exec(s), null !== u);) y = c.lastIndex, c === f$2 ? "!--" === u[1] ? c = v : void 0 !== u[1] ? c = _ : void 0 !== u[2] ? ($.test(u[2]) && (r = RegExp("</" + u[2], "g")), c = m$1) : void 0 !== u[3] && (c = m$1) : c === m$1 ? ">" === u[0] ? (c = r ?? f$2, d = -1) : void 0 === u[1] ? d = -2 : (d = c.lastIndex - u[2].length, a = u[1], c = void 0 === u[3] ? m$1 : '"' === u[3] ? g : p) : c === g || c === p ? c = m$1 : c === v || c === _ ? c = f$2 : (c = m$1, r = void 0);
-    const x = c === m$1 && t[i + 1].startsWith("/>") ? " " : "";
-    l += c === f$2 ? s + n$7 : d >= 0 ? (o.push(a), s.slice(0, d) + e$9 + s.slice(d) + h$2 + x) : s + h$2 + (-2 === d ? i : x);
+      f = 0;
+    for (; f < s.length && (c.lastIndex = f, u = c.exec(s), null !== u);) f = c.lastIndex, c === v ? "!--" === u[1] ? c = _ : void 0 !== u[1] ? c = m$1 : void 0 !== u[2] ? (y.test(u[2]) && (n = RegExp("</" + u[2], "g")), c = p$1) : void 0 !== u[3] && (c = p$1) : c === p$1 ? ">" === u[0] ? (c = n ?? v, d = -1) : void 0 === u[1] ? d = -2 : (d = c.lastIndex - u[2].length, a = u[1], c = void 0 === u[3] ? p$1 : '"' === u[3] ? $ : g) : c === $ || c === g ? c = p$1 : c === _ || c === m$1 ? c = v : (c = p$1, n = void 0);
+    const x = c === p$1 && t[i + 1].startsWith("/>") ? " " : "";
+    l += c === v ? s + r$6 : d >= 0 ? (e.push(a), s.slice(0, d) + h$2 + s.slice(d) + o$b + x) : s + o$b + (-2 === d ? i : x);
   }
-  return [P(t, l + (t[s] || "<?>") + (2 === i ? "</svg>" : 3 === i ? "</math>" : "")), o];
+  return [V(t, l + (t[s] || "<?>") + (2 === i ? "</svg>" : 3 === i ? "</math>" : "")), e];
 };
-class N {
+class S {
   constructor({
     strings: t,
-    _$litType$: s
-  }, n) {
+    _$litType$: i
+  }, e) {
     let r;
     this.parts = [];
-    let c = 0,
+    let l = 0,
       a = 0;
     const u = t.length - 1,
       d = this.parts,
-      [f, v] = V(t, s);
-    if (this.el = N.createElement(f, n), C.currentNode = this.el.content, 2 === s || 3 === s) {
+      [f, v] = N(t, i);
+    if (this.el = S.createElement(f, e), P.currentNode = this.el.content, 2 === i || 3 === i) {
       const t = this.el.content.firstChild;
       t.replaceWith(...t.childNodes);
     }
-    for (; null !== (r = C.nextNode()) && d.length < u;) {
+    for (; null !== (r = P.nextNode()) && d.length < u;) {
       if (1 === r.nodeType) {
-        if (r.hasAttributes()) for (const t of r.getAttributeNames()) if (t.endsWith(e$9)) {
+        if (r.hasAttributes()) for (const t of r.getAttributeNames()) if (t.endsWith(h$2)) {
           const i = v[a++],
-            s = r.getAttribute(t).split(h$2),
+            s = r.getAttribute(t).split(o$b),
             e = /([.?@])?(.*)/.exec(i);
           d.push({
             type: 1,
-            index: c,
+            index: l,
             name: e[2],
             strings: s,
-            ctor: "." === e[1] ? H$1 : "?" === e[1] ? I : "@" === e[1] ? L : k
+            ctor: "." === e[1] ? I : "?" === e[1] ? L : "@" === e[1] ? z : H$1
           }), r.removeAttribute(t);
-        } else t.startsWith(h$2) && (d.push({
+        } else t.startsWith(o$b) && (d.push({
           type: 6,
-          index: c
+          index: l
         }), r.removeAttribute(t));
-        if ($.test(r.tagName)) {
-          const t = r.textContent.split(h$2),
-            s = t.length - 1;
-          if (s > 0) {
-            r.textContent = i$5 ? i$5.emptyScript : "";
-            for (let i = 0; i < s; i++) r.append(t[i], l$2()), C.nextNode(), d.push({
+        if (y.test(r.tagName)) {
+          const t = r.textContent.split(o$b),
+            i = t.length - 1;
+          if (i > 0) {
+            r.textContent = s$2 ? s$2.emptyScript : "";
+            for (let s = 0; s < i; s++) r.append(t[s], c$1()), P.nextNode(), d.push({
               type: 2,
-              index: ++c
+              index: ++l
             });
-            r.append(t[s], l$2());
+            r.append(t[i], c$1());
           }
         }
-      } else if (8 === r.nodeType) if (r.data === o$a) d.push({
+      } else if (8 === r.nodeType) if (r.data === n$7) d.push({
         type: 2,
-        index: c
+        index: l
       });else {
         let t = -1;
-        for (; -1 !== (t = r.data.indexOf(h$2, t + 1));) d.push({
+        for (; -1 !== (t = r.data.indexOf(o$b, t + 1));) d.push({
           type: 7,
-          index: c
-        }), t += h$2.length - 1;
+          index: l
+        }), t += o$b.length - 1;
       }
-      c++;
+      l++;
     }
   }
   static createElement(t, i) {
-    const s = r$6.createElement("template");
+    const s = l$3.createElement("template");
     return s.innerHTML = t, s;
   }
 }
-function S(t, i, s = t, e) {
-  if (i === T) return i;
+function M(t, i, s = t, e) {
+  if (i === E) return i;
   let h = void 0 !== e ? s._$Co?.[e] : s._$Cl;
-  const o = c$1(i) ? void 0 : i._$litDirective$;
-  return h?.constructor !== o && (h?._$AO?.(false), void 0 === o ? h = void 0 : (h = new o(t), h._$AT(t, s, e)), void 0 !== e ? (s._$Co ??= [])[e] = h : s._$Cl = h), void 0 !== h && (i = S(t, h._$AS(t, i.values), h, e)), i;
+  const o = a$1(i) ? void 0 : i._$litDirective$;
+  return h?.constructor !== o && (h?._$AO?.(false), void 0 === o ? h = void 0 : (h = new o(t), h._$AT(t, s, e)), void 0 !== e ? (s._$Co ??= [])[e] = h : s._$Cl = h), void 0 !== h && (i = M(t, h._$AS(t, i.values), h, e)), i;
 }
-class M {
+class R {
   constructor(t, i) {
     this._$AV = [], this._$AN = void 0, this._$AD = t, this._$AM = i;
   }
@@ -6789,32 +6644,32 @@ class M {
         },
         parts: s
       } = this._$AD,
-      e = (t?.creationScope ?? r$6).importNode(i, true);
-    C.currentNode = e;
-    let h = C.nextNode(),
+      e = (t?.creationScope ?? l$3).importNode(i, true);
+    P.currentNode = e;
+    let h = P.nextNode(),
       o = 0,
       n = 0,
-      l = s[0];
-    for (; void 0 !== l;) {
-      if (o === l.index) {
+      r = s[0];
+    for (; void 0 !== r;) {
+      if (o === r.index) {
         let i;
-        2 === l.type ? i = new R(h, h.nextSibling, this, t) : 1 === l.type ? i = new l.ctor(h, l.name, l.strings, this, t) : 6 === l.type && (i = new z(h, this, t)), this._$AV.push(i), l = s[++n];
+        2 === r.type ? i = new k(h, h.nextSibling, this, t) : 1 === r.type ? i = new r.ctor(h, r.name, r.strings, this, t) : 6 === r.type && (i = new Z(h, this, t)), this._$AV.push(i), r = s[++n];
       }
-      o !== l?.index && (h = C.nextNode(), o++);
+      o !== r?.index && (h = P.nextNode(), o++);
     }
-    return C.currentNode = r$6, e;
+    return P.currentNode = l$3, e;
   }
   p(t) {
     let i = 0;
     for (const s of this._$AV) void 0 !== s && (void 0 !== s.strings ? (s._$AI(t, s, i), i += s.strings.length - 2) : s._$AI(t[i])), i++;
   }
 }
-class R {
+class k {
   get _$AU() {
     return this._$AM?._$AU ?? this._$Cv;
   }
   constructor(t, i, s, e) {
-    this.type = 2, this._$AH = E, this._$AN = void 0, this._$AA = t, this._$AB = i, this._$AM = s, this.options = e, this._$Cv = e?.isConnected ?? true;
+    this.type = 2, this._$AH = A, this._$AN = void 0, this._$AA = t, this._$AB = i, this._$AM = s, this.options = e, this._$Cv = e?.isConnected ?? true;
   }
   get parentNode() {
     let t = this._$AA.parentNode;
@@ -6828,7 +6683,7 @@ class R {
     return this._$AB;
   }
   _$AI(t, i = this) {
-    t = S(this, t, i), c$1(t) ? t === E || null == t || "" === t ? (this._$AH !== E && this._$AR(), this._$AH = E) : t !== this._$AH && t !== T && this._(t) : void 0 !== t._$litType$ ? this.$(t) : void 0 !== t.nodeType ? this.T(t) : u$2(t) ? this.k(t) : this._(t);
+    t = M(this, t, i), a$1(t) ? t === A || null == t || "" === t ? (this._$AH !== A && this._$AR(), this._$AH = A) : t !== this._$AH && t !== E && this._(t) : void 0 !== t._$litType$ ? this.$(t) : void 0 !== t.nodeType ? this.T(t) : d(t) ? this.k(t) : this._(t);
   }
   O(t) {
     return this._$AA.parentNode.insertBefore(t, this._$AB);
@@ -6837,43 +6692,43 @@ class R {
     this._$AH !== t && (this._$AR(), this._$AH = this.O(t));
   }
   _(t) {
-    this._$AH !== E && c$1(this._$AH) ? this._$AA.nextSibling.data = t : this.T(r$6.createTextNode(t)), this._$AH = t;
+    this._$AH !== A && a$1(this._$AH) ? this._$AA.nextSibling.data = t : this.T(l$3.createTextNode(t)), this._$AH = t;
   }
   $(t) {
     const {
         values: i,
         _$litType$: s
       } = t,
-      e = "number" == typeof s ? this._$AC(t) : (void 0 === s.el && (s.el = N.createElement(P(s.h, s.h[0]), this.options)), s);
+      e = "number" == typeof s ? this._$AC(t) : (void 0 === s.el && (s.el = S.createElement(V(s.h, s.h[0]), this.options)), s);
     if (this._$AH?._$AD === e) this._$AH.p(i);else {
-      const t = new M(e, this),
+      const t = new R(e, this),
         s = t.u(this.options);
       t.p(i), this.T(s), this._$AH = t;
     }
   }
   _$AC(t) {
-    let i = A.get(t.strings);
-    return void 0 === i && A.set(t.strings, i = new N(t)), i;
+    let i = C.get(t.strings);
+    return void 0 === i && C.set(t.strings, i = new S(t)), i;
   }
   k(t) {
-    a$1(this._$AH) || (this._$AH = [], this._$AR());
+    u$1(this._$AH) || (this._$AH = [], this._$AR());
     const i = this._$AH;
     let s,
       e = 0;
-    for (const h of t) e === i.length ? i.push(s = new R(this.O(l$2()), this.O(l$2()), this, this.options)) : s = i[e], s._$AI(h), e++;
+    for (const h of t) e === i.length ? i.push(s = new k(this.O(c$1()), this.O(c$1()), this, this.options)) : s = i[e], s._$AI(h), e++;
     e < i.length && (this._$AR(s && s._$AB.nextSibling, e), i.length = e);
   }
-  _$AR(t = this._$AA.nextSibling, i) {
-    for (this._$AP?.(false, true, i); t && t !== this._$AB;) {
-      const i = t.nextSibling;
-      t.remove(), t = i;
+  _$AR(t = this._$AA.nextSibling, s) {
+    for (this._$AP?.(false, true, s); t !== this._$AB;) {
+      const s = i$5(t).nextSibling;
+      i$5(t).remove(), t = s;
     }
   }
   setConnected(t) {
     void 0 === this._$AM && (this._$Cv = t, this._$AP?.(t));
   }
 }
-class k {
+let H$1 = class H {
   get tagName() {
     return this.element.tagName;
   }
@@ -6881,54 +6736,54 @@ class k {
     return this._$AM._$AU;
   }
   constructor(t, i, s, e, h) {
-    this.type = 1, this._$AH = E, this._$AN = void 0, this.element = t, this.name = i, this._$AM = e, this.options = h, s.length > 2 || "" !== s[0] || "" !== s[1] ? (this._$AH = Array(s.length - 1).fill(new String()), this.strings = s) : this._$AH = E;
+    this.type = 1, this._$AH = A, this._$AN = void 0, this.element = t, this.name = i, this._$AM = e, this.options = h, s.length > 2 || "" !== s[0] || "" !== s[1] ? (this._$AH = Array(s.length - 1).fill(new String()), this.strings = s) : this._$AH = A;
   }
   _$AI(t, i = this, s, e) {
     const h = this.strings;
     let o = false;
-    if (void 0 === h) t = S(this, t, i, 0), o = !c$1(t) || t !== this._$AH && t !== T, o && (this._$AH = t);else {
+    if (void 0 === h) t = M(this, t, i, 0), o = !a$1(t) || t !== this._$AH && t !== E, o && (this._$AH = t);else {
       const e = t;
       let n, r;
-      for (t = h[0], n = 0; n < h.length - 1; n++) r = S(this, e[s + n], i, n), r === T && (r = this._$AH[n]), o ||= !c$1(r) || r !== this._$AH[n], r === E ? t = E : t !== E && (t += (r ?? "") + h[n + 1]), this._$AH[n] = r;
+      for (t = h[0], n = 0; n < h.length - 1; n++) r = M(this, e[s + n], i, n), r === E && (r = this._$AH[n]), o ||= !a$1(r) || r !== this._$AH[n], r === A ? t = A : t !== A && (t += (r ?? "") + h[n + 1]), this._$AH[n] = r;
     }
     o && !e && this.j(t);
   }
   j(t) {
-    t === E ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, t ?? "");
+    t === A ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, t ?? "");
   }
-}
-let H$1 = class H extends k {
+};
+class I extends H$1 {
   constructor() {
     super(...arguments), this.type = 3;
   }
   j(t) {
-    this.element[this.name] = t === E ? void 0 : t;
+    this.element[this.name] = t === A ? void 0 : t;
   }
-};
-class I extends k {
+}
+class L extends H$1 {
   constructor() {
     super(...arguments), this.type = 4;
   }
   j(t) {
-    this.element.toggleAttribute(this.name, !!t && t !== E);
+    this.element.toggleAttribute(this.name, !!t && t !== A);
   }
 }
-class L extends k {
+class z extends H$1 {
   constructor(t, i, s, e, h) {
     super(t, i, s, e, h), this.type = 5;
   }
   _$AI(t, i = this) {
-    if ((t = S(this, t, i, 0) ?? E) === T) return;
+    if ((t = M(this, t, i, 0) ?? A) === E) return;
     const s = this._$AH,
-      e = t === E && s !== E || t.capture !== s.capture || t.once !== s.once || t.passive !== s.passive,
-      h = t !== E && (s === E || e);
+      e = t === A && s !== A || t.capture !== s.capture || t.once !== s.once || t.passive !== s.passive,
+      h = t !== A && (s === A || e);
     e && this.element.removeEventListener(this.name, this, s), h && this.element.addEventListener(this.name, this, t), this._$AH = t;
   }
   handleEvent(t) {
     "function" == typeof this._$AH ? this._$AH.call(this.options?.host ?? this.element, t) : this._$AH.handleEvent(t);
   }
 }
-class z {
+class Z {
   constructor(t, i, s) {
     this.element = t, this.type = 6, this._$AN = void 0, this._$AM = i, this.options = s;
   }
@@ -6936,17 +6791,17 @@ class z {
     return this._$AM._$AU;
   }
   _$AI(t) {
-    S(this, t);
+    M(this, t);
   }
 }
-const j = t$3.litHtmlPolyfillSupport;
-j?.(N, R), (t$3.litHtmlVersions ??= []).push("3.2.1");
-const B = (t, i, s) => {
+const B = t$3.litHtmlPolyfillSupport;
+B?.(S, k), (t$3.litHtmlVersions ??= []).push("3.3.2");
+const D = (t, i, s) => {
   const e = s?.renderBefore ?? i;
   let h = e._$litPart$;
   if (void 0 === h) {
     const t = s?.renderBefore ?? null;
-    e._$litPart$ = h = new R(i.insertBefore(l$2(), t), t, void 0, s ?? {});
+    e._$litPart$ = h = new k(i.insertBefore(c$1(), t), t, void 0, s ?? {});
   }
   return h._$AI(t), h;
 };
@@ -6956,7 +6811,8 @@ const B = (t, i, s) => {
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-let r$5 = class r extends b {
+const s$1 = globalThis;
+let i$4 = class i extends y$1 {
   constructor() {
     super(...arguments), this.renderOptions = {
       host: this
@@ -6967,8 +6823,8 @@ let r$5 = class r extends b {
     return this.renderOptions.renderBefore ??= t.firstChild, t;
   }
   update(t) {
-    const s = this.render();
-    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t), this._$Do = B(s, this.renderRoot, this.renderOptions);
+    const r = this.render();
+    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t), this._$Do = D(r, this.renderRoot, this.renderOptions);
   }
   connectedCallback() {
     super.connectedCallback(), this._$Do?.setConnected(true);
@@ -6977,17 +6833,17 @@ let r$5 = class r extends b {
     super.disconnectedCallback(), this._$Do?.setConnected(false);
   }
   render() {
-    return T;
+    return E;
   }
 };
-r$5._$litElement$ = true, r$5["finalized"] = true, globalThis.litElementHydrateSupport?.({
-  LitElement: r$5
+i$4._$litElement$ = true, i$4["finalized"] = true, s$1.litElementHydrateSupport?.({
+  LitElement: i$4
 });
-const i$4 = globalThis.litElementPolyfillSupport;
-i$4?.({
-  LitElement: r$5
+const o$a = s$1.litElementPolyfillSupport;
+o$a?.({
+  LitElement: i$4
 });
-(globalThis.litElementVersions ??= []).push("4.1.1");
+(s$1.litElementVersions ??= []).push("4.2.2");
 
 // src/components/visually-hidden/visually-hidden.styles.ts
 var visually_hidden_styles_default = i$7`
@@ -7100,27 +6956,27 @@ var __yieldStar = value => {
 const o$9 = {
     attribute: true,
     type: String,
-    converter: u$3,
+    converter: u$2,
     reflect: false,
-    hasChanged: f$3
+    hasChanged: f$2
   },
-  r$4 = (t = o$9, e, r) => {
+  r$5 = (t = o$9, e, r) => {
     const {
       kind: n,
       metadata: i
     } = r;
     let s = globalThis.litPropertyMetadata.get(i);
-    if (void 0 === s && globalThis.litPropertyMetadata.set(i, s = new Map()), s.set(r.name, t), "accessor" === n) {
+    if (void 0 === s && globalThis.litPropertyMetadata.set(i, s = new Map()), "setter" === n && ((t = Object.create(t)).wrapped = true), s.set(r.name, t), "accessor" === n) {
       const {
         name: o
       } = r;
       return {
         set(r) {
           const n = e.get.call(this);
-          e.set.call(this, r), this.requestUpdate(o, n, t);
+          e.set.call(this, r), this.requestUpdate(o, n, t, true, r);
         },
         init(e) {
-          return void 0 !== e && this.P(o, void 0, t), e;
+          return void 0 !== e && this.C(o, void 0, t, e), e;
         }
       };
     }
@@ -7130,18 +6986,15 @@ const o$9 = {
       } = r;
       return function (r) {
         const n = this[o];
-        e.call(this, r), this.requestUpdate(o, n, t);
+        e.call(this, r), this.requestUpdate(o, n, t, true, r);
       };
     }
     throw Error("Unsupported decorator location: " + n);
   };
 function n$6(t) {
-  return (e, o) => "object" == typeof o ? r$4(t, e, o) : ((t, e, o) => {
+  return (e, o) => "object" == typeof o ? r$5(t, e, o) : ((t, e, o) => {
     const r = e.hasOwnProperty(o);
-    return e.constructor.createProperty(o, r ? {
-      ...t,
-      wrapped: true
-    } : t), r ? Object.getOwnPropertyDescriptor(e, o) : void 0;
+    return e.constructor.createProperty(o, t), r ? Object.getOwnPropertyDescriptor(e, o) : void 0;
   })(t, e, o);
 }
 
@@ -7150,7 +7003,7 @@ function n$6(t) {
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-function r$3(r) {
+function r$4(r) {
   return n$6({
     ...r,
     state: true,
@@ -7175,17 +7028,17 @@ function t$2(t) {
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const e$8 = (e, t, c) => (c.configurable = true, c.enumerable = true, Reflect.decorate && "object" != typeof t && Object.defineProperty(e, t, c), c);
+const e$7 = (e, t, c) => (c.configurable = true, c.enumerable = true, Reflect.decorate && "object" != typeof t && Object.defineProperty(e, t, c), c);
 
 /**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-function e$7(e, r) {
+function e$6(e, r) {
   return (n, s, i) => {
     const o = t => t.renderRoot?.querySelector(e) ?? null;
-    return e$8(n, s, {
+    return e$7(n, s, {
       get() {
         return o(this);
       }
@@ -7198,8 +7051,8 @@ function e$7(e, r) {
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-function r$2(r) {
-  return (n, e) => e$8(n, e, {
+function r$3(r) {
+  return (n, e) => e$7(n, e, {
     async get() {
       return await this.updateComplete, this.renderRoot?.querySelector(r) ?? null;
     }
@@ -7207,7 +7060,7 @@ function r$2(r) {
 }
 
 var _hasRecordedInitialProperties;
-var ShoelaceElement = class extends r$5 {
+var ShoelaceElement = class extends i$4 {
   constructor() {
     super();
     __privateAdd(this, _hasRecordedInitialProperties, false);
@@ -7281,7 +7134,7 @@ __decorateClass([n$6()], ShoelaceElement.prototype, "lang", 2);
 
 var SlVisuallyHidden = class extends ShoelaceElement {
   render() {
-    return x` <slot></slot> `;
+    return b` <slot></slot> `;
   }
 };
 SlVisuallyHidden.styles = [component_styles_default, visually_hidden_styles_default];
@@ -7291,7 +7144,7 @@ SlVisuallyHidden.styles = [component_styles_default, visually_hidden_styles_defa
  * Copyright 2018 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const e$6 = new Set(["children", "localName", "ref", "style", "className"]),
+const e$5 = new Set(["children", "localName", "ref", "style", "className"]),
   n$5 = new WeakMap(),
   t$1 = (e, t, o, l, a) => {
     const s = a?.[t];
@@ -7317,7 +7170,7 @@ const e$6 = new Set(["children", "localName", "ref", "style", "className"]),
           d = n.useRef(null),
           f = {},
           u = {};
-        for (const [n, t] of Object.entries(s)) e$6.has(n) ? f["className" === n ? "class" : n] = t : c.has(n) || n in l.prototype ? u[n] = t : f[n] = t;
+        for (const [n, t] of Object.entries(s)) e$5.has(n) ? f["className" === n ? "class" : n] = t : c.has(n) || n in l.prototype ? u[n] = t : f[n] = t;
         return n.useLayoutEffect(() => {
           if (null === d.current) return;
           const e = new Map();
@@ -7682,10 +7535,10 @@ function watch(propertyName, options) {
  * Copyright 2020 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const e$5 = (o, t) => void 0 !== o?._$litType$ ,
-  f$1 = o => void 0 === o.strings,
-  u$1 = {},
-  m = (o, t = u$1) => o._$AH = t;
+const l$2 = (o, t) => void 0 !== o?._$litType$ ,
+  r$2 = o => void 0 === o.strings,
+  m = {},
+  p = (o, t = m) => o._$AH = t;
 
 var CACHEABLE_ERROR = Symbol();
 var RETRYABLE_ERROR = Symbol();
@@ -7704,7 +7557,7 @@ var SlIcon = class extends ShoelaceElement {
     var _a;
     let fileData;
     if (library == null ? void 0 : library.spriteSheet) {
-      this.svg = x`<svg part="svg">
+      this.svg = b`<svg part="svg">
         <use part="use" href="${url}"></use>
       </svg>`;
       return this.svg;
@@ -7795,7 +7648,7 @@ var SlIcon = class extends ShoelaceElement {
     if (url !== this.getIconSource().url) {
       return;
     }
-    if (e$5(svg)) {
+    if (l$2(svg)) {
       this.svg = svg;
       if (library) {
         await this.updateComplete;
@@ -7823,7 +7676,7 @@ var SlIcon = class extends ShoelaceElement {
   }
 };
 SlIcon.styles = [component_styles_default, icon_styles_default];
-__decorateClass([r$3()], SlIcon.prototype, "svg", 2);
+__decorateClass([r$4()], SlIcon.prototype, "svg", 2);
 __decorateClass([n$6({
   reflect: true
 })], SlIcon.prototype, "name", 2);
@@ -7889,7 +7742,7 @@ const e$3 = e$4(class extends i$3 {
       const s = !!i[t];
       s === this.st.has(t) || this.nt?.has(t) || (s ? (r.add(t), this.st.add(t)) : (r.remove(t), this.st.delete(t)));
     }
-    return T;
+    return E;
   }
 });
 
@@ -7928,14 +7781,14 @@ const a = Symbol.for(""),
     }
     return t(r, ...e);
   },
-  u = n$4(x);
+  u = n$4(b);
 
 /**
  * @license
  * Copyright 2018 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const o$6 = o => o ?? E;
+const o$6 = o => o ?? A;
 
 var SlIconButton = class extends ShoelaceElement {
   constructor() {
@@ -8010,8 +7863,8 @@ SlIconButton.styles = [component_styles_default, icon_button_styles_default];
 SlIconButton.dependencies = {
   "sl-icon": SlIcon
 };
-__decorateClass([e$7(".icon-button")], SlIconButton.prototype, "button", 2);
-__decorateClass([r$3()], SlIconButton.prototype, "hasFocus", 2);
+__decorateClass([e$6(".icon-button")], SlIconButton.prototype, "button", 2);
+__decorateClass([r$4()], SlIconButton.prototype, "hasFocus", 2);
 __decorateClass([n$6()], SlIconButton.prototype, "name", 2);
 __decorateClass([n$6()], SlIconButton.prototype, "library", 2);
 __decorateClass([n$6()], SlIconButton.prototype, "src", 2);
@@ -8216,7 +8069,7 @@ var SlTab = class extends ShoelaceElement {
   }
   render() {
     this.id = this.id.length > 0 ? this.id : this.componentId;
-    return x`
+    return b`
       <div
         part="base"
         class=${e$3({
@@ -8227,7 +8080,7 @@ var SlTab = class extends ShoelaceElement {
     })}
       >
         <slot></slot>
-        ${this.closable ? x`
+        ${this.closable ? b`
               <sl-icon-button
                 part="close-button"
                 exportparts="base:close-button__base"
@@ -8247,7 +8100,7 @@ SlTab.styles = [component_styles_default, tab_styles_default];
 SlTab.dependencies = {
   "sl-icon-button": SlIconButton
 };
-__decorateClass([e$7(".tab")], SlTab.prototype, "tab", 2);
+__decorateClass([e$6(".tab")], SlTab.prototype, "tab", 2);
 __decorateClass([n$6({
   reflect: true
 })], SlTab.prototype, "panel", 2);
@@ -8580,7 +8433,7 @@ var SlResizeObserver = class extends ShoelaceElement {
     }
   }
   render() {
-    return x` <slot @slotchange=${this.handleSlotChange}></slot> `;
+    return b` <slot @slotchange=${this.handleSlotChange}></slot> `;
   }
 };
 SlResizeObserver.styles = [component_styles_default, resize_observer_styles_default];
@@ -8991,7 +8844,7 @@ var SlTabGroup = class extends ShoelaceElement {
   }
   render() {
     const isRtl = this.localize.dir() === "rtl";
-    return x`
+    return b`
       <div
         part="base"
         class=${e$3({
@@ -9007,7 +8860,7 @@ var SlTabGroup = class extends ShoelaceElement {
         @keydown=${this.handleKeyDown}
       >
         <div class="tab-group__nav-container" part="nav">
-          ${this.hasScrollControls ? x`
+          ${this.hasScrollControls ? b`
                 <sl-icon-button
                   part="scroll-button scroll-button--start"
                   exportparts="base:scroll-button__base"
@@ -9034,7 +8887,7 @@ var SlTabGroup = class extends ShoelaceElement {
             </div>
           </div>
 
-          ${this.hasScrollControls ? x`
+          ${this.hasScrollControls ? b`
                 <sl-icon-button
                   part="scroll-button scroll-button--end"
                   exportparts="base:scroll-button__base"
@@ -9063,13 +8916,13 @@ SlTabGroup.dependencies = {
   "sl-icon-button": SlIconButton,
   "sl-resize-observer": SlResizeObserver
 };
-__decorateClass([e$7(".tab-group")], SlTabGroup.prototype, "tabGroup", 2);
-__decorateClass([e$7(".tab-group__body")], SlTabGroup.prototype, "body", 2);
-__decorateClass([e$7(".tab-group__nav")], SlTabGroup.prototype, "nav", 2);
-__decorateClass([e$7(".tab-group__indicator")], SlTabGroup.prototype, "indicator", 2);
-__decorateClass([r$3()], SlTabGroup.prototype, "hasScrollControls", 2);
-__decorateClass([r$3()], SlTabGroup.prototype, "shouldHideScrollStartButton", 2);
-__decorateClass([r$3()], SlTabGroup.prototype, "shouldHideScrollEndButton", 2);
+__decorateClass([e$6(".tab-group")], SlTabGroup.prototype, "tabGroup", 2);
+__decorateClass([e$6(".tab-group__body")], SlTabGroup.prototype, "body", 2);
+__decorateClass([e$6(".tab-group__nav")], SlTabGroup.prototype, "nav", 2);
+__decorateClass([e$6(".tab-group__indicator")], SlTabGroup.prototype, "indicator", 2);
+__decorateClass([r$4()], SlTabGroup.prototype, "hasScrollControls", 2);
+__decorateClass([r$4()], SlTabGroup.prototype, "shouldHideScrollStartButton", 2);
+__decorateClass([r$4()], SlTabGroup.prototype, "shouldHideScrollEndButton", 2);
 __decorateClass([n$6()], SlTabGroup.prototype, "placement", 2);
 __decorateClass([n$6()], SlTabGroup.prototype, "activation", 2);
 __decorateClass([n$6({
@@ -9140,7 +8993,7 @@ var SlTabPanel = class extends ShoelaceElement {
     this.setAttribute("aria-hidden", this.active ? "false" : "true");
   }
   render() {
-    return x`
+    return b`
       <slot
         part="base"
         class=${e$3({
@@ -9301,7 +9154,7 @@ var SlTag = class extends ShoelaceElement {
     this.emit("sl-remove");
   }
   render() {
-    return x`
+    return b`
       <span
         part="base"
         class=${e$3({
@@ -9324,7 +9177,7 @@ var SlTag = class extends ShoelaceElement {
       >
         <slot part="content" class="tag__content"></slot>
 
-        ${this.removable ? x`
+        ${this.removable ? b`
               <sl-icon-button
                 part="remove-button"
                 exportparts="base:remove-button__base"
@@ -9557,8 +9410,8 @@ var defaultValue = (propertyName = "value") => (proto, key) => {
     const options = ctor.getPropertyOptions(propertyName);
     const attributeName = typeof options.attribute === "string" ? options.attribute : propertyName;
     if (name === attributeName) {
-      const converter = options.converter || u$3;
-      const fromAttribute = typeof converter === "function" ? converter : (_a = converter == null ? void 0 : converter.fromAttribute) != null ? _a : u$3.fromAttribute;
+      const converter = options.converter || u$2;
+      const fromAttribute = typeof converter === "function" ? converter : (_a = converter == null ? void 0 : converter.fromAttribute) != null ? _a : u$2.fromAttribute;
       const newValue = fromAttribute(value, options.type);
       if (this[propertyName] !== newValue) {
         this[key] = newValue;
@@ -9985,21 +9838,21 @@ function getTextContent(slot) {
 const l = e$4(class extends i$3 {
   constructor(r) {
     if (super(r), r.type !== t.PROPERTY && r.type !== t.ATTRIBUTE && r.type !== t.BOOLEAN_ATTRIBUTE) throw Error("The `live` directive is not allowed on child or event bindings");
-    if (!f$1(r)) throw Error("`live` bindings can only contain a single expression");
+    if (!r$2(r)) throw Error("`live` bindings can only contain a single expression");
   }
   render(r) {
     return r;
   }
   update(i, [t$1]) {
-    if (t$1 === T || t$1 === E) return t$1;
+    if (t$1 === E || t$1 === A) return t$1;
     const o = i.element,
       l = i.name;
     if (i.type === t.PROPERTY) {
-      if (t$1 === o[l]) return T;
+      if (t$1 === o[l]) return E;
     } else if (i.type === t.BOOLEAN_ATTRIBUTE) {
-      if (!!t$1 === o.hasAttribute(l)) return T;
-    } else if (i.type === t.ATTRIBUTE && o.getAttribute(l) === t$1 + "") return T;
-    return m(i), t$1;
+      if (!!t$1 === o.hasAttribute(l)) return E;
+    } else if (i.type === t.ATTRIBUTE && o.getAttribute(l) === t$1 + "") return E;
+    return p(i), t$1;
   }
 });
 
@@ -10155,7 +10008,7 @@ var SlTextarea = class extends ShoelaceElement {
     const hasHelpTextSlot = this.hasSlotController.test("help-text");
     const hasLabel = this.label ? true : !!hasLabelSlot;
     const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
-    return x`
+    return b`
       <div
         part="form-control"
         class=${e$3({
@@ -10239,9 +10092,9 @@ var SlTextarea = class extends ShoelaceElement {
   }
 };
 SlTextarea.styles = [component_styles_default, form_control_styles_default, textarea_styles_default];
-__decorateClass([e$7(".textarea__control")], SlTextarea.prototype, "input", 2);
-__decorateClass([e$7(".textarea__size-adjuster")], SlTextarea.prototype, "sizeAdjuster", 2);
-__decorateClass([r$3()], SlTextarea.prototype, "hasFocus", 2);
+__decorateClass([e$6(".textarea__control")], SlTextarea.prototype, "input", 2);
+__decorateClass([e$6(".textarea__size-adjuster")], SlTextarea.prototype, "sizeAdjuster", 2);
+__decorateClass([r$4()], SlTextarea.prototype, "hasFocus", 2);
 __decorateClass([n$6()], SlTextarea.prototype, "title", 2);
 __decorateClass([n$6()], SlTextarea.prototype, "name", 2);
 __decorateClass([n$6()], SlTextarea.prototype, "value", 2);
@@ -10460,10 +10313,6 @@ const oppositeSideMap = {
   bottom: 'top',
   top: 'bottom'
 };
-const oppositeAlignmentMap = {
-  start: 'end',
-  end: 'start'
-};
 function clamp$1(start, value, end) {
   return max(start, min(value, end));
 }
@@ -10483,7 +10332,8 @@ function getAxisLength(axis) {
   return axis === 'y' ? 'height' : 'width';
 }
 function getSideAxis(placement) {
-  return ['top', 'bottom'].includes(getSide(placement)) ? 'y' : 'x';
+  const firstChar = placement[0];
+  return firstChar === 't' || firstChar === 'b' ? 'y' : 'x';
 }
 function getAlignmentAxis(placement) {
   return getOppositeAxis(getSideAxis(placement));
@@ -10506,21 +10356,21 @@ function getExpandedPlacements(placement) {
   return [getOppositeAlignmentPlacement(placement), oppositePlacement, getOppositeAlignmentPlacement(oppositePlacement)];
 }
 function getOppositeAlignmentPlacement(placement) {
-  return placement.replace(/start|end/g, alignment => oppositeAlignmentMap[alignment]);
+  return placement.includes('start') ? placement.replace('start', 'end') : placement.replace('end', 'start');
 }
+const lrPlacement = ['left', 'right'];
+const rlPlacement = ['right', 'left'];
+const tbPlacement = ['top', 'bottom'];
+const btPlacement = ['bottom', 'top'];
 function getSideList(side, isStart, rtl) {
-  const lr = ['left', 'right'];
-  const rl = ['right', 'left'];
-  const tb = ['top', 'bottom'];
-  const bt = ['bottom', 'top'];
   switch (side) {
     case 'top':
     case 'bottom':
-      if (rtl) return isStart ? rl : lr;
-      return isStart ? lr : rl;
+      if (rtl) return isStart ? rlPlacement : lrPlacement;
+      return isStart ? lrPlacement : rlPlacement;
     case 'left':
     case 'right':
-      return isStart ? tb : bt;
+      return isStart ? tbPlacement : btPlacement;
     default:
       return [];
   }
@@ -10537,7 +10387,8 @@ function getOppositeAxisPlacements(placement, flipAlignment, direction, rtl) {
   return list;
 }
 function getOppositePlacement(placement) {
-  return placement.replace(/left|right|bottom|top/g, side => oppositeSideMap[side]);
+  const side = getSide(placement);
+  return oppositeSideMap[side] + placement.slice(side.length);
 }
 function expandPaddingObject(padding) {
   return {
@@ -10632,97 +10483,6 @@ function computeCoordsFromPlacement(_ref, placement, rtl) {
 }
 
 /**
- * Computes the `x` and `y` coordinates that will place the floating element
- * next to a given reference element.
- *
- * This export does not have any `platform` interface logic. You will need to
- * write one for the platform you are using Floating UI with.
- */
-const computePosition$1 = async (reference, floating, config) => {
-  const {
-    placement = 'bottom',
-    strategy = 'absolute',
-    middleware = [],
-    platform
-  } = config;
-  const validMiddleware = middleware.filter(Boolean);
-  const rtl = await (platform.isRTL == null ? void 0 : platform.isRTL(floating));
-  let rects = await platform.getElementRects({
-    reference,
-    floating,
-    strategy
-  });
-  let {
-    x,
-    y
-  } = computeCoordsFromPlacement(rects, placement, rtl);
-  let statefulPlacement = placement;
-  let middlewareData = {};
-  let resetCount = 0;
-  for (let i = 0; i < validMiddleware.length; i++) {
-    const {
-      name,
-      fn
-    } = validMiddleware[i];
-    const {
-      x: nextX,
-      y: nextY,
-      data,
-      reset
-    } = await fn({
-      x,
-      y,
-      initialPlacement: placement,
-      placement: statefulPlacement,
-      strategy,
-      middlewareData,
-      rects,
-      platform,
-      elements: {
-        reference,
-        floating
-      }
-    });
-    x = nextX != null ? nextX : x;
-    y = nextY != null ? nextY : y;
-    middlewareData = {
-      ...middlewareData,
-      [name]: {
-        ...middlewareData[name],
-        ...data
-      }
-    };
-    if (reset && resetCount <= 50) {
-      resetCount++;
-      if (typeof reset === 'object') {
-        if (reset.placement) {
-          statefulPlacement = reset.placement;
-        }
-        if (reset.rects) {
-          rects = reset.rects === true ? await platform.getElementRects({
-            reference,
-            floating,
-            strategy
-          }) : reset.rects;
-        }
-        ({
-          x,
-          y
-        } = computeCoordsFromPlacement(rects, statefulPlacement, rtl));
-      }
-      i = -1;
-    }
-  }
-  return {
-    x,
-    y,
-    placement: statefulPlacement,
-    strategy,
-    middlewareData
-  };
-};
-
-/**
  * Resolves with an object of overflow side offsets that determine how much the
  * element is overflowing a given clipping boundary on each side.
  * - positive = overflowing the boundary by that number of pixels
@@ -10786,6 +10546,104 @@ async function detectOverflow(state, options) {
     right: (elementClientRect.right - clippingClientRect.right + paddingObject.right) / offsetScale.x
   };
 }
+
+// Maximum number of resets that can occur before bailing to avoid infinite reset loops.
+const MAX_RESET_COUNT = 50;
+
+/**
+ * Computes the `x` and `y` coordinates that will place the floating element
+ * next to a given reference element.
+ *
+ * This export does not have any `platform` interface logic. You will need to
+ * write one for the platform you are using Floating UI with.
+ */
+const computePosition$1 = async (reference, floating, config) => {
+  const {
+    placement = 'bottom',
+    strategy = 'absolute',
+    middleware = [],
+    platform
+  } = config;
+  const platformWithDetectOverflow = platform.detectOverflow ? platform : {
+    ...platform,
+    detectOverflow
+  };
+  const rtl = await (platform.isRTL == null ? void 0 : platform.isRTL(floating));
+  let rects = await platform.getElementRects({
+    reference,
+    floating,
+    strategy
+  });
+  let {
+    x,
+    y
+  } = computeCoordsFromPlacement(rects, placement, rtl);
+  let statefulPlacement = placement;
+  let resetCount = 0;
+  const middlewareData = {};
+  for (let i = 0; i < middleware.length; i++) {
+    const currentMiddleware = middleware[i];
+    if (!currentMiddleware) {
+      continue;
+    }
+    const {
+      name,
+      fn
+    } = currentMiddleware;
+    const {
+      x: nextX,
+      y: nextY,
+      data,
+      reset
+    } = await fn({
+      x,
+      y,
+      initialPlacement: placement,
+      placement: statefulPlacement,
+      strategy,
+      middlewareData,
+      rects,
+      platform: platformWithDetectOverflow,
+      elements: {
+        reference,
+        floating
+      }
+    });
+    x = nextX != null ? nextX : x;
+    y = nextY != null ? nextY : y;
+    middlewareData[name] = {
+      ...middlewareData[name],
+      ...data
+    };
+    if (reset && resetCount < MAX_RESET_COUNT) {
+      resetCount++;
+      if (typeof reset === 'object') {
+        if (reset.placement) {
+          statefulPlacement = reset.placement;
+        }
+        if (reset.rects) {
+          rects = reset.rects === true ? await platform.getElementRects({
+            reference,
+            floating,
+            strategy
+          }) : reset.rects;
+        }
+        ({
+          x,
+          y
+        } = computeCoordsFromPlacement(rects, statefulPlacement, rtl));
+      }
+      i = -1;
+    }
+  }
+  return {
+    x,
+    y,
+    placement: statefulPlacement,
+    strategy,
+    middlewareData
+  };
+};
 
 /**
  * Provides data to position an inner element of the floating element so that it
@@ -10919,7 +10777,7 @@ const flip$2 = function (options) {
         fallbackPlacements.push(...getOppositeAxisPlacements(initialPlacement, flipAlignment, fallbackAxisSideDirection, rtl));
       }
       const placements = [initialPlacement, ...fallbackPlacements];
-      const overflow = await detectOverflow(state, detectOverflowOptions);
+      const overflow = await platform.detectOverflow(state, detectOverflowOptions);
       const overflows = [];
       let overflowsData = ((_middlewareData$flip = middlewareData.flip) == null ? void 0 : _middlewareData$flip.overflows) || [];
       if (checkMainAxis) {
@@ -10940,16 +10798,22 @@ const flip$2 = function (options) {
         const nextIndex = (((_middlewareData$flip2 = middlewareData.flip) == null ? void 0 : _middlewareData$flip2.index) || 0) + 1;
         const nextPlacement = placements[nextIndex];
         if (nextPlacement) {
-          // Try next placement and re-run the lifecycle.
-          return {
-            data: {
-              index: nextIndex,
-              overflows: overflowsData
-            },
-            reset: {
-              placement: nextPlacement
-            }
-          };
+          const ignoreCrossAxisOverflow = checkCrossAxis === 'alignment' ? initialSideAxis !== getSideAxis(nextPlacement) : false;
+          if (!ignoreCrossAxisOverflow ||
+          // We leave the current main axis only if every placement on that axis
+          // overflows the main axis.
+          overflowsData.every(d => getSideAxis(d.placement) === initialSideAxis ? d.overflows[0] > 0 : true)) {
+            // Try next placement and re-run the lifecycle.
+            return {
+              data: {
+                index: nextIndex,
+                overflows: overflowsData
+              },
+              reset: {
+                placement: nextPlacement
+              }
+            };
+          }
         }
 
         // First, find the candidates that fit on the mainAxis side of overflow,
@@ -10994,6 +10858,7 @@ const flip$2 = function (options) {
     }
   };
 };
+const originSides = /*#__PURE__*/new Set(['left', 'top']);
 
 // For type backwards-compatibility, the `OffsetOptions` type was also
 // Derivable.
@@ -11008,7 +10873,7 @@ async function convertValueToCoords(state, options) {
   const side = getSide(placement);
   const alignment = getAlignment(placement);
   const isVertical = getSideAxis(placement) === 'y';
-  const mainAxisMulti = ['left', 'top'].includes(side) ? -1 : 1;
+  const mainAxisMulti = originSides.has(side) ? -1 : 1;
   const crossAxisMulti = rtl && isVertical ? -1 : 1;
   const rawValue = evaluate(options, state);
 
@@ -11095,7 +10960,8 @@ const shift$1 = function (options) {
       const {
         x,
         y,
-        placement
+        placement,
+        platform
       } = state;
       const {
         mainAxis: checkMainAxis = true,
@@ -11118,7 +10984,7 @@ const shift$1 = function (options) {
         x,
         y
       };
-      const overflow = await detectOverflow(state, detectOverflowOptions);
+      const overflow = await platform.detectOverflow(state, detectOverflowOptions);
       const crossAxis = getSideAxis(getSide(placement));
       const mainAxis = getOppositeAxis(crossAxis);
       let mainAxisCoord = coords[mainAxis];
@@ -11182,7 +11048,7 @@ const size$1 = function (options) {
         apply = () => {},
         ...detectOverflowOptions
       } = evaluate(options, state);
-      const overflow = await detectOverflow(state, detectOverflowOptions);
+      const overflow = await platform.detectOverflow(state, detectOverflowOptions);
       const side = getSide(placement);
       const alignment = getAlignment(placement);
       const isYAxis = getSideAxis(placement) === 'y';
@@ -11292,26 +11158,35 @@ function isOverflowElement(element) {
     overflowY,
     display
   } = getComputedStyle$1(element);
-  return /auto|scroll|overlay|hidden|clip/.test(overflow + overflowY + overflowX) && !['inline', 'contents'].includes(display);
+  return /auto|scroll|overlay|hidden|clip/.test(overflow + overflowY + overflowX) && display !== 'inline' && display !== 'contents';
 }
 function isTableElement(element) {
-  return ['table', 'td', 'th'].includes(getNodeName(element));
+  return /^(table|td|th)$/.test(getNodeName(element));
 }
 function isTopLayer(element) {
-  return [':popover-open', ':modal'].some(selector => {
-    try {
-      return element.matches(selector);
-    } catch (e) {
-      return false;
+  try {
+    if (element.matches(':popover-open')) {
+      return true;
     }
-  });
+  } catch (_e) {
+    // no-op
+  }
+  try {
+    return element.matches(':modal');
+  } catch (_e) {
+    return false;
+  }
 }
+const willChangeRe = /transform|translate|scale|rotate|perspective|filter/;
+const containRe = /paint|layout|strict|content/;
+const isNotNone = value => !!value && value !== 'none';
+let isWebKitValue;
 function isContainingBlock(elementOrCss) {
-  const webkit = isWebKit();
   const css = isElement(elementOrCss) ? getComputedStyle$1(elementOrCss) : elementOrCss;
 
   // https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block
-  return css.transform !== 'none' || css.perspective !== 'none' || (css.containerType ? css.containerType !== 'normal' : false) || !webkit && (css.backdropFilter ? css.backdropFilter !== 'none' : false) || !webkit && (css.filter ? css.filter !== 'none' : false) || ['transform', 'perspective', 'filter'].some(value => (css.willChange || '').includes(value)) || ['paint', 'layout', 'strict', 'content'].some(value => (css.contain || '').includes(value));
+  // https://drafts.csswg.org/css-transforms-2/#individual-transforms
+  return isNotNone(css.transform) || isNotNone(css.translate) || isNotNone(css.scale) || isNotNone(css.rotate) || isNotNone(css.perspective) || !isWebKit() && (isNotNone(css.backdropFilter) || isNotNone(css.filter)) || willChangeRe.test(css.willChange || '') || containRe.test(css.contain || '');
 }
 function getContainingBlock(element) {
   let currentNode = getParentNode(element);
@@ -11326,11 +11201,13 @@ function getContainingBlock(element) {
   return null;
 }
 function isWebKit() {
-  if (typeof CSS === 'undefined' || !CSS.supports) return false;
-  return CSS.supports('-webkit-backdrop-filter', 'none');
+  if (isWebKitValue == null) {
+    isWebKitValue = typeof CSS !== 'undefined' && CSS.supports && CSS.supports('-webkit-backdrop-filter', 'none');
+  }
+  return isWebKitValue;
 }
 function isLastTraversableNode(node) {
-  return ['html', 'body', '#document'].includes(getNodeName(node));
+  return /^(html|body|#document)$/.test(getNodeName(node));
 }
 function getComputedStyle$1(element) {
   return getWindow(element).getComputedStyle(element);
@@ -11386,8 +11263,9 @@ function getOverflowAncestors(node, list, traverseIframes) {
   if (isBody) {
     const frameElement = getFrameElement(win);
     return list.concat(win, win.visualViewport || [], isOverflowElement(scrollableAncestor) ? scrollableAncestor : [], frameElement && traverseIframes ? getOverflowAncestors(frameElement) : []);
+  } else {
+    return list.concat(scrollableAncestor, getOverflowAncestors(scrollableAncestor, [], traverseIframes));
   }
-  return list.concat(scrollableAncestor, getOverflowAncestors(scrollableAncestor, [], traverseIframes));
 }
 function getFrameElement(win) {
   return win.parent && Object.getPrototypeOf(win.parent) ? win.frameElement : null;
@@ -11525,14 +11403,9 @@ function getWindowScrollBarX(element, rect) {
   }
   return rect.left + leftScroll;
 }
-function getHTMLOffset(documentElement, scroll, ignoreScrollbarX) {
-  if (ignoreScrollbarX === void 0) {
-    ignoreScrollbarX = false;
-  }
+function getHTMLOffset(documentElement, scroll) {
   const htmlRect = documentElement.getBoundingClientRect();
-  const x = htmlRect.left + scroll.scrollLeft - (ignoreScrollbarX ? 0 :
-  // RTL <body> scrollbar.
-  getWindowScrollBarX(documentElement, htmlRect));
+  const x = htmlRect.left + scroll.scrollLeft - getWindowScrollBarX(documentElement, htmlRect);
   const y = htmlRect.top + scroll.scrollTop;
   return {
     x,
@@ -11563,14 +11436,14 @@ function convertOffsetParentRelativeRectToViewportRelativeRect(_ref) {
     if (getNodeName(offsetParent) !== 'body' || isOverflowElement(documentElement)) {
       scroll = getNodeScroll(offsetParent);
     }
-    if (isHTMLElement(offsetParent)) {
+    if (isOffsetParentAnElement) {
       const offsetRect = getBoundingClientRect(offsetParent);
       scale = getScale(offsetParent);
       offsets.x = offsetRect.x + offsetParent.clientLeft;
       offsets.y = offsetRect.y + offsetParent.clientTop;
     }
   }
-  const htmlOffset = documentElement && !isOffsetParentAnElement && !isFixed ? getHTMLOffset(documentElement, scroll, true) : createCoords(0);
+  const htmlOffset = documentElement && !isOffsetParentAnElement && !isFixed ? getHTMLOffset(documentElement, scroll) : createCoords(0);
   return {
     width: rect.width * scale.x,
     height: rect.height * scale.y,
@@ -11602,6 +11475,11 @@ function getDocumentRect(element) {
     y
   };
 }
+
+// Safety check: ensure the scrollbar space is reasonable in case this
+// calculation is affected by unusual styles.
+// Most scrollbars leave 15-18px of space.
+const SCROLLBAR_MAX = 25;
 function getViewportRect(element, strategy) {
   const win = getWindow(element);
   const html = getDocumentElement(element);
@@ -11618,6 +11496,24 @@ function getViewportRect(element, strategy) {
       x = visualViewport.offsetLeft;
       y = visualViewport.offsetTop;
     }
+  }
+  const windowScrollbarX = getWindowScrollBarX(html);
+  // <html> `overflow: hidden` + `scrollbar-gutter: stable` reduces the
+  // visual width of the <html> but this is not considered in the size
+  // of `html.clientWidth`.
+  if (windowScrollbarX <= 0) {
+    const doc = html.ownerDocument;
+    const body = doc.body;
+    const bodyStyles = getComputedStyle(body);
+    const bodyMarginInline = doc.compatMode === 'CSS1Compat' ? parseFloat(bodyStyles.marginLeft) + parseFloat(bodyStyles.marginRight) || 0 : 0;
+    const clippingStableScrollbarWidth = Math.abs(html.clientWidth - body.clientWidth - bodyMarginInline);
+    if (clippingStableScrollbarWidth <= SCROLLBAR_MAX) {
+      width -= clippingStableScrollbarWidth;
+    }
+  } else if (windowScrollbarX <= SCROLLBAR_MAX) {
+    // If the <body> scrollbar is on the left, the width needs to be extended
+    // by the scrollbar amount so there isn't extra space on the right.
+    width += windowScrollbarX;
   }
   return {
     width,
@@ -11691,7 +11587,7 @@ function getClippingElementAncestors(element, cache) {
     if (!currentNodeIsContaining && computedStyle.position === 'fixed') {
       currentContainingBlockComputedStyle = null;
     }
-    const shouldDropCurrentNode = elementIsFixed ? !currentNodeIsContaining && !currentContainingBlockComputedStyle : !currentNodeIsContaining && computedStyle.position === 'static' && !!currentContainingBlockComputedStyle && ['absolute', 'fixed'].includes(currentContainingBlockComputedStyle.position) || isOverflowElement(currentNode) && !currentNodeIsContaining && hasFixedPositionAncestor(element, currentNode);
+    const shouldDropCurrentNode = elementIsFixed ? !currentNodeIsContaining && !currentContainingBlockComputedStyle : !currentNodeIsContaining && computedStyle.position === 'static' && !!currentContainingBlockComputedStyle && (currentContainingBlockComputedStyle.position === 'absolute' || currentContainingBlockComputedStyle.position === 'fixed') || isOverflowElement(currentNode) && !currentNodeIsContaining && hasFixedPositionAncestor(element, currentNode);
     if (shouldDropCurrentNode) {
       // Drop non-containing blocks.
       result = result.filter(ancestor => ancestor !== currentNode);
@@ -11716,20 +11612,23 @@ function getClippingRect(_ref) {
   } = _ref;
   const elementClippingAncestors = boundary === 'clippingAncestors' ? isTopLayer(element) ? [] : getClippingElementAncestors(element, this._c) : [].concat(boundary);
   const clippingAncestors = [...elementClippingAncestors, rootBoundary];
-  const firstClippingAncestor = clippingAncestors[0];
-  const clippingRect = clippingAncestors.reduce((accRect, clippingAncestor) => {
-    const rect = getClientRectFromClippingAncestor(element, clippingAncestor, strategy);
-    accRect.top = max(rect.top, accRect.top);
-    accRect.right = min(rect.right, accRect.right);
-    accRect.bottom = min(rect.bottom, accRect.bottom);
-    accRect.left = max(rect.left, accRect.left);
-    return accRect;
-  }, getClientRectFromClippingAncestor(element, firstClippingAncestor, strategy));
+  const firstRect = getClientRectFromClippingAncestor(element, clippingAncestors[0], strategy);
+  let top = firstRect.top;
+  let right = firstRect.right;
+  let bottom = firstRect.bottom;
+  let left = firstRect.left;
+  for (let i = 1; i < clippingAncestors.length; i++) {
+    const rect = getClientRectFromClippingAncestor(element, clippingAncestors[i], strategy);
+    top = max(rect.top, top);
+    right = min(rect.right, right);
+    bottom = min(rect.bottom, bottom);
+    left = max(rect.left, left);
+  }
   return {
-    width: clippingRect.right - clippingRect.left,
-    height: clippingRect.bottom - clippingRect.top,
-    x: clippingRect.left,
-    y: clippingRect.top
+    width: right - left,
+    height: bottom - top,
+    x: left,
+    y: top
   };
 }
 function getDimensions(element) {
@@ -11752,6 +11651,12 @@ function getRectRelativeToOffsetParent(element, offsetParent, strategy) {
     scrollTop: 0
   };
   const offsets = createCoords(0);
+
+  // If the <body> scrollbar appears on the left (e.g. RTL systems). Use
+  // Firefox with layout.scrollbar.side = 3 in about:config to test this.
+  function setLeftRTLScrollbarOffset() {
+    offsets.x = getWindowScrollBarX(documentElement);
+  }
   if (isOffsetParentAnElement || !isOffsetParentAnElement && !isFixed) {
     if (getNodeName(offsetParent) !== 'body' || isOverflowElement(documentElement)) {
       scroll = getNodeScroll(offsetParent);
@@ -11761,10 +11666,11 @@ function getRectRelativeToOffsetParent(element, offsetParent, strategy) {
       offsets.x = offsetRect.x + offsetParent.clientLeft;
       offsets.y = offsetRect.y + offsetParent.clientTop;
     } else if (documentElement) {
-      // If the <body> scrollbar appears on the left (e.g. RTL systems). Use
-      // Firefox with layout.scrollbar.side = 3 in about:config to test this.
-      offsets.x = getWindowScrollBarX(documentElement);
+      setLeftRTLScrollbarOffset();
     }
+  }
+  if (isFixed && !isOffsetParentAnElement && documentElement) {
+    setLeftRTLScrollbarOffset();
   }
   const htmlOffset = documentElement && !isOffsetParentAnElement && !isFixed ? getHTMLOffset(documentElement, scroll) : createCoords(0);
   const x = rect.left + scroll.scrollLeft - offsets.x - htmlOffset.x;
@@ -11853,6 +11759,9 @@ const platform = {
   isElement,
   isRTL
 };
+function rectsAreEqual(a, b) {
+  return a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height;
+}
 
 // https://samthor.au/2021/observing-dom/
 function observeMove(element, onMove) {
@@ -11873,12 +11782,13 @@ function observeMove(element, onMove) {
       threshold = 1;
     }
     cleanup();
+    const elementRectForRootMargin = element.getBoundingClientRect();
     const {
       left,
       top,
       width,
       height
-    } = element.getBoundingClientRect();
+    } = elementRectForRootMargin;
     if (!skip) {
       onMove();
     }
@@ -11911,6 +11821,16 @@ function observeMove(element, onMove) {
           refresh(false, ratio);
         }
       }
+      if (ratio === 1 && !rectsAreEqual(elementRectForRootMargin, element.getBoundingClientRect())) {
+        // It's possible that even though the ratio is reported as 1, the
+        // element is not actually fully within the IntersectionObserver's root
+        // area anymore. This can happen under performance constraints. This may
+        // be a bug in the browser's IntersectionObserver implementation. To
+        // work around this, we compare the element's bounding rect now with
+        // what it was at the time we created the IntersectionObserver. If they
+        // are not equal then the element moved, so we refresh.
+        refresh();
+      }
       isFirstUpdate = false;
     }
 
@@ -11922,7 +11842,7 @@ function observeMove(element, onMove) {
         // Handle <iframe>s
         root: root.ownerDocument
       });
-    } catch (e) {
+    } catch (_e) {
       io = new IntersectionObserver(handleObserve, options);
     }
     io.observe(element);
@@ -11951,7 +11871,7 @@ function autoUpdate(reference, floating, update, options) {
     animationFrame = false
   } = options;
   const referenceEl = unwrapElement(reference);
-  const ancestors = ancestorScroll || ancestorResize ? [...(referenceEl ? getOverflowAncestors(referenceEl) : []), ...getOverflowAncestors(floating)] : [];
+  const ancestors = ancestorScroll || ancestorResize ? [...(referenceEl ? getOverflowAncestors(referenceEl) : []), ...(floating ? getOverflowAncestors(floating) : [])] : [];
   ancestors.forEach(ancestor => {
     ancestorScroll && ancestor.addEventListener('scroll', update, {
       passive: true
@@ -11964,7 +11884,7 @@ function autoUpdate(reference, floating, update, options) {
   if (elementResize) {
     resizeObserver = new ResizeObserver(_ref => {
       let [firstEntry] = _ref;
-      if (firstEntry && firstEntry.target === referenceEl && resizeObserver) {
+      if (firstEntry && firstEntry.target === referenceEl && resizeObserver && floating) {
         // Prevent update loops when using the `size` middleware.
         // https://github.com/floating-ui/floating-ui/issues/1740
         resizeObserver.unobserve(floating);
@@ -11979,7 +11899,9 @@ function autoUpdate(reference, floating, update, options) {
     if (referenceEl && !animationFrame) {
       resizeObserver.observe(referenceEl);
     }
-    resizeObserver.observe(floating);
+    if (floating) {
+      resizeObserver.observe(floating);
+    }
   }
   let frameId;
   let prevRefRect = animationFrame ? getBoundingClientRect(reference) : null;
@@ -11988,7 +11910,7 @@ function autoUpdate(reference, floating, update, options) {
   }
   function frameLoop() {
     const nextRefRect = getBoundingClientRect(reference);
-    if (prevRefRect && (nextRefRect.x !== prevRefRect.x || nextRefRect.y !== prevRefRect.y || nextRefRect.width !== prevRefRect.width || nextRefRect.height !== prevRefRect.height)) {
+    if (prevRefRect && !rectsAreEqual(prevRefRect, nextRefRect)) {
       update();
     }
     prevRefRect = nextRefRect;
@@ -12380,7 +12302,7 @@ var SlPopup = class extends ShoelaceElement {
     this.emit("sl-reposition");
   }
   render() {
-    return x`
+    return b`
       <slot name="anchor" @slotchange=${this.handleAnchorChange}></slot>
 
       <span
@@ -12401,14 +12323,14 @@ var SlPopup = class extends ShoelaceElement {
     })}
       >
         <slot></slot>
-        ${this.arrow ? x`<div part="arrow" class="popup__arrow" role="presentation"></div>` : ""}
+        ${this.arrow ? b`<div part="arrow" class="popup__arrow" role="presentation"></div>` : ""}
       </div>
     `;
   }
 };
 SlPopup.styles = [component_styles_default, popup_styles_default];
-__decorateClass([e$7(".popup")], SlPopup.prototype, "popup", 2);
-__decorateClass([e$7(".popup__arrow")], SlPopup.prototype, "arrowEl", 2);
+__decorateClass([e$6(".popup")], SlPopup.prototype, "popup", 2);
+__decorateClass([e$6(".popup__arrow")], SlPopup.prototype, "arrowEl", 2);
 __decorateClass([n$6()], SlPopup.prototype, "anchor", 2);
 __decorateClass([n$6({
   type: Boolean,
@@ -12737,7 +12659,7 @@ var SlTooltip = class extends ShoelaceElement {
   // element, otherwise positioning is incorrect.
   //
   render() {
-    return x`
+    return b`
       <sl-popup
         part="base"
         exportparts="
@@ -12772,9 +12694,9 @@ SlTooltip.styles = [component_styles_default, tooltip_styles_default];
 SlTooltip.dependencies = {
   "sl-popup": SlPopup
 };
-__decorateClass([e$7("slot:not([name])")], SlTooltip.prototype, "defaultSlot", 2);
-__decorateClass([e$7(".tooltip__body")], SlTooltip.prototype, "body", 2);
-__decorateClass([e$7("sl-popup")], SlTooltip.prototype, "popup", 2);
+__decorateClass([e$6("slot:not([name])")], SlTooltip.prototype, "defaultSlot", 2);
+__decorateClass([e$6(".tooltip__body")], SlTooltip.prototype, "body", 2);
+__decorateClass([e$6("sl-popup")], SlTooltip.prototype, "popup", 2);
 __decorateClass([n$6()], SlTooltip.prototype, "content", 2);
 __decorateClass([n$6()], SlTooltip.prototype, "placement", 2);
 __decorateClass([n$6({
@@ -13213,7 +13135,7 @@ var SlCheckbox = class extends ShoelaceElement {
   render() {
     const hasHelpTextSlot = this.hasSlotController.test("help-text");
     const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
-    return x`
+    return b`
       <div
         class=${e$3({
       "form-control": true,
@@ -13259,10 +13181,10 @@ var SlCheckbox = class extends ShoelaceElement {
             part="control${this.checked ? " control--checked" : ""}${this.indeterminate ? " control--indeterminate" : ""}"
             class="checkbox__control"
           >
-            ${this.checked ? x`
+            ${this.checked ? b`
                   <sl-icon part="checked-icon" class="checkbox__checked-icon" library="system" name="check"></sl-icon>
                 ` : ""}
-            ${!this.checked && this.indeterminate ? x`
+            ${!this.checked && this.indeterminate ? b`
                   <sl-icon
                     part="indeterminate-icon"
                     class="checkbox__indeterminate-icon"
@@ -13293,8 +13215,8 @@ SlCheckbox.styles = [component_styles_default, form_control_styles_default, chec
 SlCheckbox.dependencies = {
   "sl-icon": SlIcon
 };
-__decorateClass([e$7('input[type="checkbox"]')], SlCheckbox.prototype, "input", 2);
-__decorateClass([r$3()], SlCheckbox.prototype, "hasFocus", 2);
+__decorateClass([e$6('input[type="checkbox"]')], SlCheckbox.prototype, "input", 2);
+__decorateClass([r$4()], SlCheckbox.prototype, "hasFocus", 2);
 __decorateClass([n$6()], SlCheckbox.prototype, "title", 2);
 __decorateClass([n$6()], SlCheckbox.prototype, "name", 2);
 __decorateClass([n$6()], SlCheckbox.prototype, "value", 2);
@@ -13397,7 +13319,7 @@ var SlSpinner = class extends ShoelaceElement {
     this.localize = new LocalizeController(this);
   }
   render() {
-    return x`
+    return b`
       <svg part="base" class="spinner" role="progressbar" aria-label=${this.localize.term("loading")}>
         <circle class="spinner__track"></circle>
         <circle class="spinner__indicator"></circle>
@@ -13532,7 +13454,7 @@ var _SlTreeItem = class _SlTreeItem extends ShoelaceElement {
   render() {
     const isRtl = this.localize.dir() === "rtl";
     const showExpandButton = !this.loading && (!this.isLeaf || this.lazy);
-    return x`
+    return b`
       <div
         part="base"
         class="${e$3({
@@ -13565,7 +13487,7 @@ var _SlTreeItem = class _SlTreeItem extends ShoelaceElement {
     })}
             aria-hidden="true"
           >
-            ${n$3(this.loading, () => x` <sl-spinner part="spinner" exportparts="base:spinner__base"></sl-spinner> `)}
+            ${n$3(this.loading, () => b` <sl-spinner part="spinner" exportparts="base:spinner__base"></sl-spinner> `)}
             <slot class="tree-item__expand-icon-slot" name="expand-icon">
               <sl-icon library="system" name=${isRtl ? "chevron-left" : "chevron-right"}></sl-icon>
             </slot>
@@ -13574,7 +13496,7 @@ var _SlTreeItem = class _SlTreeItem extends ShoelaceElement {
             </slot>
           </div>
 
-          ${n$3(this.selectable, () => x`
+          ${n$3(this.selectable, () => b`
               <sl-checkbox
                 part="checkbox"
                 exportparts="
@@ -13610,10 +13532,10 @@ _SlTreeItem.dependencies = {
   "sl-icon": SlIcon,
   "sl-spinner": SlSpinner
 };
-__decorateClass([r$3()], _SlTreeItem.prototype, "indeterminate", 2);
-__decorateClass([r$3()], _SlTreeItem.prototype, "isLeaf", 2);
-__decorateClass([r$3()], _SlTreeItem.prototype, "loading", 2);
-__decorateClass([r$3()], _SlTreeItem.prototype, "selectable", 2);
+__decorateClass([r$4()], _SlTreeItem.prototype, "indeterminate", 2);
+__decorateClass([r$4()], _SlTreeItem.prototype, "isLeaf", 2);
+__decorateClass([r$4()], _SlTreeItem.prototype, "loading", 2);
+__decorateClass([r$4()], _SlTreeItem.prototype, "selectable", 2);
 __decorateClass([n$6({
   type: Boolean,
   reflect: true
@@ -13630,11 +13552,11 @@ __decorateClass([n$6({
   type: Boolean,
   reflect: true
 })], _SlTreeItem.prototype, "lazy", 2);
-__decorateClass([e$7("slot:not([name])")], _SlTreeItem.prototype, "defaultSlot", 2);
-__decorateClass([e$7("slot[name=children]")], _SlTreeItem.prototype, "childrenSlot", 2);
-__decorateClass([e$7(".tree-item__item")], _SlTreeItem.prototype, "itemElement", 2);
-__decorateClass([e$7(".tree-item__children")], _SlTreeItem.prototype, "childrenContainer", 2);
-__decorateClass([e$7(".tree-item__expand-button slot")], _SlTreeItem.prototype, "expandButtonSlot", 2);
+__decorateClass([e$6("slot:not([name])")], _SlTreeItem.prototype, "defaultSlot", 2);
+__decorateClass([e$6("slot[name=children]")], _SlTreeItem.prototype, "childrenSlot", 2);
+__decorateClass([e$6(".tree-item__item")], _SlTreeItem.prototype, "itemElement", 2);
+__decorateClass([e$6(".tree-item__children")], _SlTreeItem.prototype, "childrenContainer", 2);
+__decorateClass([e$6(".tree-item__expand-button slot")], _SlTreeItem.prototype, "expandButtonSlot", 2);
 __decorateClass([watch("loading", {
   waitUntilFirstUpdate: true
 })], _SlTreeItem.prototype, "handleLoadingChange", 1);
@@ -13989,7 +13911,7 @@ var SlTree = class extends ShoelaceElement {
     });
   }
   render() {
-    return x`
+    return b`
       <div
         part="base"
         class="tree"
@@ -14005,9 +13927,9 @@ var SlTree = class extends ShoelaceElement {
   }
 };
 SlTree.styles = [component_styles_default, tree_styles_default];
-__decorateClass([e$7("slot:not([name])")], SlTree.prototype, "defaultSlot", 2);
-__decorateClass([e$7("slot[name=expand-icon]")], SlTree.prototype, "expandedIconSlot", 2);
-__decorateClass([e$7("slot[name=collapse-icon]")], SlTree.prototype, "collapsedIconSlot", 2);
+__decorateClass([e$6("slot:not([name])")], SlTree.prototype, "defaultSlot", 2);
+__decorateClass([e$6("slot[name=expand-icon]")], SlTree.prototype, "expandedIconSlot", 2);
+__decorateClass([e$6("slot[name=collapse-icon]")], SlTree.prototype, "collapsedIconSlot", 2);
 __decorateClass([n$6()], SlTree.prototype, "selection", 2);
 __decorateClass([watch("selection")], SlTree.prototype, "handleSelectionChange", 1);
 
@@ -14145,7 +14067,7 @@ const n$2 = "important",
           t.includes("-") || r ? s.setProperty(t, r ? e.slice(0, -11) : e, r ? n$2 : "") : s[t] = e;
         }
       }
-      return T;
+      return E;
     }
   });
 
@@ -14156,11 +14078,11 @@ const n$2 = "important",
  */
 let e$1 = class e extends i$3 {
   constructor(i) {
-    if (super(i), this.it = E, i.type !== t.CHILD) throw Error(this.constructor.directiveName + "() can only be used in child bindings");
+    if (super(i), this.it = A, i.type !== t.CHILD) throw Error(this.constructor.directiveName + "() can only be used in child bindings");
   }
   render(r) {
-    if (r === E || null == r) return this._t = void 0, this.it = r;
-    if (r === T) return r;
+    if (r === A || null == r) return this._t = void 0, this.it = r;
+    if (r === E) return r;
     if ("string" != typeof r) throw Error(this.constructor.directiveName + "() called with a non-string value");
     if (r === this.it) return this._t;
     this.it = r;
@@ -14309,7 +14231,7 @@ var SlRating = class extends ShoelaceElement {
     } else {
       displayValue = this.isHovering ? this.hoverValue : this.value;
     }
-    return x`
+    return b`
       <div
         part="base"
         class=${e$3({
@@ -14338,7 +14260,7 @@ var SlRating = class extends ShoelaceElement {
         <span class="rating__symbols">
           ${counter.map(index => {
       if (displayValue > index && displayValue < index + 1) {
-        return x`
+        return b`
                 <span
                   class=${e$3({
           rating__symbol: true,
@@ -14365,7 +14287,7 @@ var SlRating = class extends ShoelaceElement {
                 </span>
               `;
       }
-      return x`
+      return b`
               <span
                 class=${e$3({
         rating__symbol: true,
@@ -14387,9 +14309,9 @@ SlRating.styles = [component_styles_default, rating_styles_default];
 SlRating.dependencies = {
   "sl-icon": SlIcon
 };
-__decorateClass([e$7(".rating")], SlRating.prototype, "rating", 2);
-__decorateClass([r$3()], SlRating.prototype, "hoverValue", 2);
-__decorateClass([r$3()], SlRating.prototype, "isHovering", 2);
+__decorateClass([e$6(".rating")], SlRating.prototype, "rating", 2);
+__decorateClass([r$4()], SlRating.prototype, "hoverValue", 2);
+__decorateClass([r$4()], SlRating.prototype, "isHovering", 2);
 __decorateClass([n$6()], SlRating.prototype, "label", 2);
 __decorateClass([n$6({
   type: Number
@@ -14510,11 +14432,11 @@ var SlRelativeTime = class extends ShoelaceElement {
       }
       this.updateTimeout = window.setTimeout(() => this.requestUpdate(), nextInterval);
     }
-    return x` <time datetime=${this.isoTime}>${this.relativeTime}</time> `;
+    return b` <time datetime=${this.isoTime}>${this.relativeTime}</time> `;
   }
 };
-__decorateClass([r$3()], SlRelativeTime.prototype, "isoTime", 2);
-__decorateClass([r$3()], SlRelativeTime.prototype, "relativeTime", 2);
+__decorateClass([r$4()], SlRelativeTime.prototype, "isoTime", 2);
+__decorateClass([r$4()], SlRelativeTime.prototype, "relativeTime", 2);
 __decorateClass([n$6()], SlRelativeTime.prototype, "date", 2);
 __decorateClass([n$6()], SlRelativeTime.prototype, "format", 2);
 __decorateClass([n$6()], SlRelativeTime.prototype, "numeric", 2);
@@ -14931,7 +14853,7 @@ var SlSelect = class extends ShoelaceElement {
     this.form = "";
     this.required = false;
     this.getTag = option => {
-      return x`
+      return b`
       <sl-tag
         part="tag"
         exportparts="
@@ -15289,13 +15211,13 @@ var SlSelect = class extends ShoelaceElement {
     return this.selectedOptions.map((option, index) => {
       if (index < this.maxOptionsVisible || this.maxOptionsVisible <= 0) {
         const tag = this.getTag(option, index);
-        return x`<div @sl-remove=${e => this.handleTagRemove(e, option)}>
+        return b`<div @sl-remove=${e => this.handleTagRemove(e, option)}>
           ${typeof tag === "string" ? o$4(tag) : tag}
         </div>`;
       } else if (index === this.maxOptionsVisible) {
-        return x`<sl-tag size=${this.size}>+${this.selectedOptions.length - index}</sl-tag>`;
+        return b`<sl-tag size=${this.size}>+${this.selectedOptions.length - index}</sl-tag>`;
       }
-      return x``;
+      return b``;
     });
   }
   handleInvalid(event) {
@@ -15414,7 +15336,7 @@ var SlSelect = class extends ShoelaceElement {
     const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
     const hasClearIcon = this.clearable && !this.disabled && this.value.length > 0;
     const isPlaceholderVisible = this.placeholder && this.value && this.value.length <= 0;
-    return x`
+    return b`
       <div
         part="form-control"
         class=${e$3({
@@ -15494,7 +15416,7 @@ var SlSelect = class extends ShoelaceElement {
                 @blur=${this.handleBlur}
               />
 
-              ${this.multiple ? x`<div part="tags" class="select__tags">${this.tags}</div>` : ""}
+              ${this.multiple ? b`<div part="tags" class="select__tags">${this.tags}</div>` : ""}
 
               <input
                 class="select__value-input"
@@ -15508,7 +15430,7 @@ var SlSelect = class extends ShoelaceElement {
                 @invalid=${this.handleInvalid}
               />
 
-              ${hasClearIcon ? x`
+              ${hasClearIcon ? b`
                     <button
                       part="clear-button"
                       class="select__clear"
@@ -15566,18 +15488,18 @@ SlSelect.dependencies = {
   "sl-popup": SlPopup,
   "sl-tag": SlTag
 };
-__decorateClass([e$7(".select")], SlSelect.prototype, "popup", 2);
-__decorateClass([e$7(".select__combobox")], SlSelect.prototype, "combobox", 2);
-__decorateClass([e$7(".select__display-input")], SlSelect.prototype, "displayInput", 2);
-__decorateClass([e$7(".select__value-input")], SlSelect.prototype, "valueInput", 2);
-__decorateClass([e$7(".select__listbox")], SlSelect.prototype, "listbox", 2);
-__decorateClass([r$3()], SlSelect.prototype, "hasFocus", 2);
-__decorateClass([r$3()], SlSelect.prototype, "displayLabel", 2);
-__decorateClass([r$3()], SlSelect.prototype, "currentOption", 2);
-__decorateClass([r$3()], SlSelect.prototype, "selectedOptions", 2);
-__decorateClass([r$3()], SlSelect.prototype, "valueHasChanged", 2);
+__decorateClass([e$6(".select")], SlSelect.prototype, "popup", 2);
+__decorateClass([e$6(".select__combobox")], SlSelect.prototype, "combobox", 2);
+__decorateClass([e$6(".select__display-input")], SlSelect.prototype, "displayInput", 2);
+__decorateClass([e$6(".select__value-input")], SlSelect.prototype, "valueInput", 2);
+__decorateClass([e$6(".select__listbox")], SlSelect.prototype, "listbox", 2);
+__decorateClass([r$4()], SlSelect.prototype, "hasFocus", 2);
+__decorateClass([r$4()], SlSelect.prototype, "displayLabel", 2);
+__decorateClass([r$4()], SlSelect.prototype, "currentOption", 2);
+__decorateClass([r$4()], SlSelect.prototype, "selectedOptions", 2);
+__decorateClass([r$4()], SlSelect.prototype, "valueHasChanged", 2);
 __decorateClass([n$6()], SlSelect.prototype, "name", 2);
-__decorateClass([r$3()], SlSelect.prototype, "value", 1);
+__decorateClass([r$4()], SlSelect.prototype, "value", 1);
 __decorateClass([n$6({
   attribute: "value"
 })], SlSelect.prototype, "defaultValue", 2);
@@ -15766,7 +15688,7 @@ var SlSkeleton = class extends ShoelaceElement {
     this.effect = "none";
   }
   render() {
-    return x`
+    return b`
       <div
         part="base"
         class=${e$3({
@@ -16064,7 +15986,7 @@ var SlSwitch = class extends ShoelaceElement {
   render() {
     const hasHelpTextSlot = this.hasSlotController.test("help-text");
     const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
-    return x`
+    return b`
       <div
         class=${e$3({
       "form-control": true,
@@ -16128,8 +16050,8 @@ var SlSwitch = class extends ShoelaceElement {
   }
 };
 SlSwitch.styles = [component_styles_default, form_control_styles_default, switch_styles_default];
-__decorateClass([e$7('input[type="checkbox"]')], SlSwitch.prototype, "input", 2);
-__decorateClass([r$3()], SlSwitch.prototype, "hasFocus", 2);
+__decorateClass([e$6('input[type="checkbox"]')], SlSwitch.prototype, "input", 2);
+__decorateClass([r$4()], SlSwitch.prototype, "hasFocus", 2);
 __decorateClass([n$6()], SlSwitch.prototype, "title", 2);
 __decorateClass([n$6()], SlSwitch.prototype, "name", 2);
 __decorateClass([n$6()], SlSwitch.prototype, "value", 2);
@@ -16500,7 +16422,7 @@ var SlSplitPanel = class extends ShoelaceElement {
       }
     }
     this.style[gridTemplateAlt] = "";
-    return x`
+    return b`
       <slot name="start" part="panel start" class="start"></slot>
 
       <div
@@ -16524,7 +16446,7 @@ var SlSplitPanel = class extends ShoelaceElement {
   }
 };
 SlSplitPanel.styles = [component_styles_default, split_panel_styles_default];
-__decorateClass([e$7(".divider")], SlSplitPanel.prototype, "divider", 2);
+__decorateClass([e$6(".divider")], SlSplitPanel.prototype, "divider", 2);
 __decorateClass([n$6({
   type: Number,
   reflect: true
@@ -16629,7 +16551,7 @@ var SlMutationObserver = class extends ShoelaceElement {
     this.startObserver();
   }
   render() {
-    return x` <slot></slot> `;
+    return b` <slot></slot> `;
   }
 };
 SlMutationObserver.styles = [component_styles_default, mutation_observer_styles_default];
@@ -16779,7 +16701,7 @@ var SlProgressBar = class extends ShoelaceElement {
     this.label = "";
   }
   render() {
-    return x`
+    return b`
       <div
         part="base"
         class=${e$3({
@@ -16797,7 +16719,7 @@ var SlProgressBar = class extends ShoelaceElement {
         <div part="indicator" class="progress-bar__indicator" style=${o$5({
       width: `${this.value}%`
     })}>
-          ${!this.indeterminate ? x` <slot part="label" class="progress-bar__label"></slot> ` : ""}
+          ${!this.indeterminate ? b` <slot part="label" class="progress-bar__label"></slot> ` : ""}
         </div>
       </div>
     `;
@@ -16909,7 +16831,7 @@ var SlProgressRing = class extends ShoelaceElement {
     }
   }
   render() {
-    return x`
+    return b`
       <div
         part="base"
         class="progress-ring"
@@ -16932,8 +16854,8 @@ var SlProgressRing = class extends ShoelaceElement {
   }
 };
 SlProgressRing.styles = [component_styles_default, progress_ring_styles_default];
-__decorateClass([e$7(".progress-ring__indicator")], SlProgressRing.prototype, "indicator", 2);
-__decorateClass([r$3()], SlProgressRing.prototype, "indicatorOffset", 2);
+__decorateClass([e$6(".progress-ring__indicator")], SlProgressRing.prototype, "indicator", 2);
+__decorateClass([r$4()], SlProgressRing.prototype, "indicatorOffset", 2);
 __decorateClass([n$6({
   type: Number,
   reflect: true
@@ -17456,7 +17378,7 @@ var SlQrCode = class extends ShoelaceElement {
   }
   render() {
     var _a;
-    return x`
+    return b`
       <canvas
         part="base"
         class="qr-code"
@@ -17471,7 +17393,7 @@ var SlQrCode = class extends ShoelaceElement {
   }
 };
 SlQrCode.styles = [component_styles_default, qr_code_styles_default];
-__decorateClass([e$7("canvas")], SlQrCode.prototype, "canvas", 2);
+__decorateClass([e$6("canvas")], SlQrCode.prototype, "canvas", 2);
 __decorateClass([n$6()], SlQrCode.prototype, "value", 2);
 __decorateClass([n$6()], SlQrCode.prototype, "label", 2);
 __decorateClass([n$6({
@@ -18198,9 +18120,9 @@ var SlRadioButton = class extends ShoelaceElement {
   }
 };
 SlRadioButton.styles = [component_styles_default, radio_button_styles_default];
-__decorateClass([e$7(".button")], SlRadioButton.prototype, "input", 2);
-__decorateClass([e$7(".hidden-input")], SlRadioButton.prototype, "hiddenInput", 2);
-__decorateClass([r$3()], SlRadioButton.prototype, "hasFocus", 2);
+__decorateClass([e$6(".button")], SlRadioButton.prototype, "input", 2);
+__decorateClass([e$6(".hidden-input")], SlRadioButton.prototype, "hiddenInput", 2);
+__decorateClass([r$4()], SlRadioButton.prototype, "hasFocus", 2);
 __decorateClass([n$6({
   type: Boolean,
   reflect: true
@@ -18390,7 +18312,7 @@ var SlRadio = class extends ShoelaceElement {
     this.setAttribute("aria-disabled", this.disabled ? "true" : "false");
   }
   render() {
-    return x`
+    return b`
       <span
         part="base"
         class=${e$3({
@@ -18404,7 +18326,7 @@ var SlRadio = class extends ShoelaceElement {
     })}
       >
         <span part="${`control${this.checked ? " control--checked" : ""}`}" class="radio__control">
-          ${this.checked ? x` <sl-icon part="checked-icon" class="radio__checked-icon" library="system" name="radio"></sl-icon> ` : ""}
+          ${this.checked ? b` <sl-icon part="checked-icon" class="radio__checked-icon" library="system" name="radio"></sl-icon> ` : ""}
         </span>
 
         <slot part="label" class="radio__label"></slot>
@@ -18416,8 +18338,8 @@ SlRadio.styles = [component_styles_default, radio_styles_default];
 SlRadio.dependencies = {
   "sl-icon": SlIcon
 };
-__decorateClass([r$3()], SlRadio.prototype, "checked", 2);
-__decorateClass([r$3()], SlRadio.prototype, "hasFocus", 2);
+__decorateClass([r$4()], SlRadio.prototype, "checked", 2);
+__decorateClass([r$4()], SlRadio.prototype, "hasFocus", 2);
 __decorateClass([n$6()], SlRadio.prototype, "value", 2);
 __decorateClass([n$6({
   reflect: true
@@ -18829,7 +18751,7 @@ var SlRange = class extends ShoelaceElement {
     const hasHelpTextSlot = this.hasSlotController.test("help-text");
     const hasLabel = this.label ? true : !!hasLabelSlot;
     const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
-    return x`
+    return b`
       <div
         part="form-control"
         class=${e$3({
@@ -18885,7 +18807,7 @@ var SlRange = class extends ShoelaceElement {
               @invalid=${this.handleInvalid}
               @blur=${this.handleBlur}
             />
-            ${this.tooltip !== "none" && !this.disabled ? x`
+            ${this.tooltip !== "none" && !this.disabled ? b`
                   <output part="tooltip" class="range__tooltip">
                     ${typeof this.tooltipFormatter === "function" ? this.tooltipFormatter(this.value) : this.value}
                   </output>
@@ -18906,10 +18828,10 @@ var SlRange = class extends ShoelaceElement {
   }
 };
 SlRange.styles = [component_styles_default, form_control_styles_default, range_styles_default];
-__decorateClass([e$7(".range__control")], SlRange.prototype, "input", 2);
-__decorateClass([e$7(".range__tooltip")], SlRange.prototype, "output", 2);
-__decorateClass([r$3()], SlRange.prototype, "hasFocus", 2);
-__decorateClass([r$3()], SlRange.prototype, "hasTooltip", 2);
+__decorateClass([e$6(".range__control")], SlRange.prototype, "input", 2);
+__decorateClass([e$6(".range__tooltip")], SlRange.prototype, "output", 2);
+__decorateClass([r$4()], SlRange.prototype, "hasFocus", 2);
+__decorateClass([r$4()], SlRange.prototype, "hasTooltip", 2);
 __decorateClass([n$6()], SlRange.prototype, "title", 2);
 __decorateClass([n$6()], SlRange.prototype, "name", 2);
 __decorateClass([n$6({
@@ -19055,7 +18977,7 @@ var SlButtonGroup = class extends ShoelaceElement {
     });
   }
   render() {
-    return x`
+    return b`
       <div
         part="base"
         class="button-group"
@@ -19072,8 +18994,8 @@ var SlButtonGroup = class extends ShoelaceElement {
   }
 };
 SlButtonGroup.styles = [component_styles_default, button_group_styles_default];
-__decorateClass([e$7("slot")], SlButtonGroup.prototype, "defaultSlot", 2);
-__decorateClass([r$3()], SlButtonGroup.prototype, "disableRole", 2);
+__decorateClass([e$6("slot")], SlButtonGroup.prototype, "defaultSlot", 2);
+__decorateClass([r$4()], SlButtonGroup.prototype, "disableRole", 2);
 __decorateClass([n$6()], SlButtonGroup.prototype, "label", 2);
 function findButton(el) {
   var _a;
@@ -19294,10 +19216,10 @@ var SlRadioGroup = class extends ShoelaceElement {
     const hasHelpTextSlot = this.hasSlotController.test("help-text");
     const hasLabel = this.label ? true : !!hasLabelSlot;
     const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
-    const defaultSlot = x`
+    const defaultSlot = b`
       <slot @slotchange=${this.syncRadios} @click=${this.handleRadioClick} @keydown=${this.handleKeyDown}></slot>
     `;
-    return x`
+    return b`
       <fieldset
         part="form-control"
         class=${e$3({
@@ -19339,7 +19261,7 @@ var SlRadioGroup = class extends ShoelaceElement {
             </label>
           </div>
 
-          ${this.hasButtonGroup ? x`
+          ${this.hasButtonGroup ? b`
                 <sl-button-group part="button-group" exportparts="base:button-group__base" role="presentation">
                   ${defaultSlot}
                 </sl-button-group>
@@ -19362,11 +19284,11 @@ SlRadioGroup.styles = [component_styles_default, form_control_styles_default, ra
 SlRadioGroup.dependencies = {
   "sl-button-group": SlButtonGroup
 };
-__decorateClass([e$7("slot:not([name])")], SlRadioGroup.prototype, "defaultSlot", 2);
-__decorateClass([e$7(".radio-group__validation-input")], SlRadioGroup.prototype, "validationInput", 2);
-__decorateClass([r$3()], SlRadioGroup.prototype, "hasButtonGroup", 2);
-__decorateClass([r$3()], SlRadioGroup.prototype, "errorMessage", 2);
-__decorateClass([r$3()], SlRadioGroup.prototype, "defaultValue", 2);
+__decorateClass([e$6("slot:not([name])")], SlRadioGroup.prototype, "defaultSlot", 2);
+__decorateClass([e$6(".radio-group__validation-input")], SlRadioGroup.prototype, "validationInput", 2);
+__decorateClass([r$4()], SlRadioGroup.prototype, "hasButtonGroup", 2);
+__decorateClass([r$4()], SlRadioGroup.prototype, "errorMessage", 2);
+__decorateClass([r$4()], SlRadioGroup.prototype, "defaultValue", 2);
 __decorateClass([n$6()], SlRadioGroup.prototype, "label", 2);
 __decorateClass([n$6({
   attribute: "help-text"
@@ -19526,7 +19448,7 @@ var SlImageComparer = class extends ShoelaceElement {
   }
   render() {
     const isRtl = this.localize.dir() === "rtl";
-    return x`
+    return b`
       <div
         part="base"
         id="image-comparer"
@@ -19584,8 +19506,8 @@ SlImageComparer.styles = [component_styles_default, image_comparer_styles_defaul
 SlImageComparer.scopedElement = {
   "sl-icon": SlIcon
 };
-__decorateClass([e$7(".image-comparer")], SlImageComparer.prototype, "base", 2);
-__decorateClass([e$7(".image-comparer__handle")], SlImageComparer.prototype, "handle", 2);
+__decorateClass([e$6(".image-comparer")], SlImageComparer.prototype, "base", 2);
+__decorateClass([e$6(".image-comparer__handle")], SlImageComparer.prototype, "handle", 2);
 __decorateClass([n$6({
   type: Number,
   reflect: true
@@ -19676,7 +19598,7 @@ var SlInclude = class extends ShoelaceElement {
     }
   }
   render() {
-    return x`<slot></slot>`;
+    return b`<slot></slot>`;
   }
 };
 SlInclude.styles = [component_styles_default, include_styles_default];
@@ -19826,7 +19748,7 @@ var SlMenu = class extends ShoelaceElement {
     });
   }
   render() {
-    return x`
+    return b`
       <slot
         @slotchange=${this.handleSlotChange}
         @click=${this.handleClick}
@@ -19837,7 +19759,7 @@ var SlMenu = class extends ShoelaceElement {
   }
 };
 SlMenu.styles = [component_styles_default, menu_styles_default];
-__decorateClass([e$7("slot")], SlMenu.prototype, "defaultSlot", 2);
+__decorateClass([e$6("slot")], SlMenu.prototype, "defaultSlot", 2);
 
 var tagName$u = "sl-menu";
 SlMenu.define("sl-menu");
@@ -20340,7 +20262,7 @@ var SlInput = class extends ShoelaceElement {
     const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
     const hasClearIcon = this.clearable && !this.disabled && !this.readonly;
     const isClearIconVisible = hasClearIcon && (typeof this.value === "number" || this.value.length > 0);
-    return x`
+    return b`
       <div
         part="form-control"
         class=${e$3({
@@ -20418,7 +20340,7 @@ var SlInput = class extends ShoelaceElement {
               @blur=${this.handleBlur}
             />
 
-            ${isClearIconVisible ? x`
+            ${isClearIconVisible ? b`
                   <button
                     part="clear-button"
                     class="input__clear"
@@ -20432,7 +20354,7 @@ var SlInput = class extends ShoelaceElement {
                     </slot>
                   </button>
                 ` : ""}
-            ${this.passwordToggle && !this.disabled ? x`
+            ${this.passwordToggle && !this.disabled ? b`
                   <button
                     part="password-toggle-button"
                     class="input__password-toggle"
@@ -20441,11 +20363,11 @@ var SlInput = class extends ShoelaceElement {
                     @click=${this.handlePasswordToggle}
                     tabindex="-1"
                   >
-                    ${this.passwordVisible ? x`
+                    ${this.passwordVisible ? b`
                           <slot name="show-password-icon">
                             <sl-icon name="eye-slash" library="system"></sl-icon>
                           </slot>
-                        ` : x`
+                        ` : b`
                           <slot name="hide-password-icon">
                             <sl-icon name="eye" library="system"></sl-icon>
                           </slot>
@@ -20475,8 +20397,8 @@ SlInput.styles = [component_styles_default, form_control_styles_default, input_s
 SlInput.dependencies = {
   "sl-icon": SlIcon
 };
-__decorateClass([e$7(".input__control")], SlInput.prototype, "input", 2);
-__decorateClass([r$3()], SlInput.prototype, "hasFocus", 2);
+__decorateClass([e$6(".input__control")], SlInput.prototype, "input", 2);
+__decorateClass([r$4()], SlInput.prototype, "hasFocus", 2);
 __decorateClass([n$6()], SlInput.prototype, "title", 2);
 __decorateClass([n$6({
   reflect: true
@@ -20787,7 +20709,7 @@ class f extends i$3 {
     i !== this.isConnected && (this.isConnected = i, i ? this.reconnected?.() : this.disconnected?.()), t && (s(this, i), o$3(this));
   }
   setValue(t) {
-    if (f$1(this._$Ct)) this._$Ct._$AI(t, this);else {
+    if (r$2(this._$Ct)) this._$Ct._$AI(t, this);else {
       const i = [...this._$Ct._$AH];
       i[this._$Ci] = t, this._$Ct._$AI(i, this, 0);
     }
@@ -20806,21 +20728,21 @@ class h {}
 const o$2 = new WeakMap(),
   n = e$4(class extends f {
     render(i) {
-      return E;
+      return A;
     }
     update(i, [s]) {
-      const e = s !== this.Y;
-      return e && void 0 !== this.Y && this.rt(void 0), (e || this.lt !== this.ct) && (this.Y = s, this.ht = i.options?.host, this.rt(this.ct = i.element)), E;
+      const e = s !== this.G;
+      return e && void 0 !== this.G && this.rt(void 0), (e || this.lt !== this.ct) && (this.G = s, this.ht = i.options?.host, this.rt(this.ct = i.element)), A;
     }
     rt(t) {
-      if (this.isConnected || (t = void 0), "function" == typeof this.Y) {
+      if (this.isConnected || (t = void 0), "function" == typeof this.G) {
         const i = this.ht ?? globalThis;
         let s = o$2.get(i);
-        void 0 === s && (s = new WeakMap(), o$2.set(i, s)), void 0 !== s.get(this.Y) && this.Y.call(this.ht, void 0), s.set(this.Y, t), void 0 !== t && this.Y.call(this.ht, t);
-      } else this.Y.value = t;
+        void 0 === s && (s = new WeakMap(), o$2.set(i, s)), void 0 !== s.get(this.G) && this.G.call(this.ht, void 0), s.set(this.G, t), void 0 !== t && this.G.call(this.ht, t);
+      } else this.G.value = t;
     }
     get lt() {
-      return "function" == typeof this.Y ? o$2.get(this.ht ?? globalThis)?.get(this.Y) : this.Y?.value;
+      return "function" == typeof this.G ? o$2.get(this.ht ?? globalThis)?.get(this.G) : this.G?.value;
     }
     disconnected() {
       this.lt === this.ct && this.rt(void 0);
@@ -21050,9 +20972,9 @@ var SubmenuController = class {
   renderSubmenu() {
     const isRtl = getComputedStyle(this.host).direction === "rtl";
     if (!this.isConnected) {
-      return x` <slot name="submenu" hidden></slot> `;
+      return b` <slot name="submenu" hidden></slot> `;
     }
-    return x`
+    return b`
       <sl-popup
         ${n(this.popupRef)}
         placement=${isRtl ? "left-start" : "right-start"}
@@ -21151,7 +21073,7 @@ var SlMenuItem = class extends ShoelaceElement {
   render() {
     const isRtl = this.localize.dir() === "rtl";
     const isSubmenuExpanded = this.submenuController.isExpanded();
-    return x`
+    return b`
       <div
         id="anchor"
         part="base"
@@ -21182,7 +21104,7 @@ var SlMenuItem = class extends ShoelaceElement {
         </span>
 
         ${this.submenuController.renderSubmenu()}
-        ${this.loading ? x` <sl-spinner part="spinner" exportparts="base:spinner__base"></sl-spinner> ` : ""}
+        ${this.loading ? b` <sl-spinner part="spinner" exportparts="base:spinner__base"></sl-spinner> ` : ""}
       </div>
     `;
   }
@@ -21193,8 +21115,8 @@ SlMenuItem.dependencies = {
   "sl-popup": SlPopup,
   "sl-spinner": SlSpinner
 };
-__decorateClass([e$7("slot:not([name])")], SlMenuItem.prototype, "defaultSlot", 2);
-__decorateClass([e$7(".menu-item")], SlMenuItem.prototype, "menuItem", 2);
+__decorateClass([e$6("slot:not([name])")], SlMenuItem.prototype, "defaultSlot", 2);
+__decorateClass([e$6(".menu-item")], SlMenuItem.prototype, "menuItem", 2);
 __decorateClass([n$6()], SlMenuItem.prototype, "type", 2);
 __decorateClass([n$6({
   type: Boolean,
@@ -21245,7 +21167,7 @@ var menu_label_styles_default = i$7`
 
 var SlMenuLabel = class extends ShoelaceElement {
   render() {
-    return x` <slot part="base" class="menu-label"></slot> `;
+    return b` <slot part="base" class="menu-label"></slot> `;
   }
 };
 SlMenuLabel.styles = [component_styles_default, menu_label_styles_default];
@@ -21414,7 +21336,7 @@ var SlOption = class extends ShoelaceElement {
     return label.trim();
   }
   render() {
-    return x`
+    return b`
       <div
         part="base"
         class=${e$3({
@@ -21439,10 +21361,10 @@ SlOption.styles = [component_styles_default, option_styles_default];
 SlOption.dependencies = {
   "sl-icon": SlIcon
 };
-__decorateClass([e$7(".option__label")], SlOption.prototype, "defaultSlot", 2);
-__decorateClass([r$3()], SlOption.prototype, "current", 2);
-__decorateClass([r$3()], SlOption.prototype, "selected", 2);
-__decorateClass([r$3()], SlOption.prototype, "hasHover", 2);
+__decorateClass([e$6(".option__label")], SlOption.prototype, "defaultSlot", 2);
+__decorateClass([r$4()], SlOption.prototype, "current", 2);
+__decorateClass([r$4()], SlOption.prototype, "selected", 2);
+__decorateClass([r$4()], SlOption.prototype, "hasHover", 2);
 __decorateClass([n$6({
   reflect: true
 })], SlOption.prototype, "value", 2);
@@ -22130,7 +22052,7 @@ var SlDrawer = class extends ShoelaceElement {
     return waitForEvent(this, "sl-after-hide");
   }
   render() {
-    return x`
+    return b`
       <div
         part="base"
         class=${e$3({
@@ -22158,7 +22080,7 @@ var SlDrawer = class extends ShoelaceElement {
           aria-labelledby=${o$6(!this.noHeader ? "title" : void 0)}
           tabindex="0"
         >
-          ${!this.noHeader ? x`
+          ${!this.noHeader ? b`
                 <header part="header" class="drawer__header">
                   <h2 part="title" class="drawer__title" id="title">
                     <!-- If there's no label, use an invisible character to prevent the header from collapsing -->
@@ -22193,9 +22115,9 @@ SlDrawer.styles = [component_styles_default, drawer_styles_default];
 SlDrawer.dependencies = {
   "sl-icon-button": SlIconButton
 };
-__decorateClass([e$7(".drawer")], SlDrawer.prototype, "drawer", 2);
-__decorateClass([e$7(".drawer__panel")], SlDrawer.prototype, "panel", 2);
-__decorateClass([e$7(".drawer__overlay")], SlDrawer.prototype, "overlay", 2);
+__decorateClass([e$6(".drawer")], SlDrawer.prototype, "drawer", 2);
+__decorateClass([e$6(".drawer__panel")], SlDrawer.prototype, "panel", 2);
+__decorateClass([e$6(".drawer__overlay")], SlDrawer.prototype, "overlay", 2);
 __decorateClass([n$6({
   type: Boolean,
   reflect: true
@@ -22716,7 +22638,7 @@ var SlDropdown = class extends ShoelaceElement {
     }
   }
   render() {
-    return x`
+    return b`
       <sl-popup
         part="base"
         exportparts="popup:base__popup"
@@ -22757,9 +22679,9 @@ SlDropdown.styles = [component_styles_default, dropdown_styles_default];
 SlDropdown.dependencies = {
   "sl-popup": SlPopup
 };
-__decorateClass([e$7(".dropdown")], SlDropdown.prototype, "popup", 2);
-__decorateClass([e$7(".dropdown__trigger")], SlDropdown.prototype, "trigger", 2);
-__decorateClass([e$7(".dropdown__panel")], SlDropdown.prototype, "panel", 2);
+__decorateClass([e$6(".dropdown")], SlDropdown.prototype, "popup", 2);
+__decorateClass([e$6(".dropdown__trigger")], SlDropdown.prototype, "trigger", 2);
+__decorateClass([e$6(".dropdown__panel")], SlDropdown.prototype, "panel", 2);
 __decorateClass([n$6({
   type: Boolean,
   reflect: true
@@ -22849,7 +22771,7 @@ var SlFormatDate = class extends ShoelaceElement {
     if (isNaN(date.getMilliseconds())) {
       return void 0;
     }
-    return x`
+    return b`
       <time datetime=${date.toISOString()}>
         ${this.localize.date(date, {
       weekday: this.weekday,
@@ -23654,7 +23576,7 @@ var SlCarousel = class extends ShoelaceElement {
     const prevEnabled = this.canScrollPrev();
     const nextEnabled = this.canScrollNext();
     const isLtr = this.localize.dir() === "ltr";
-    return x`
+    return b`
       <div part="base" class="carousel">
         <div
           id="scroll-container"
@@ -23678,7 +23600,7 @@ var SlCarousel = class extends ShoelaceElement {
           <slot></slot>
         </div>
 
-        ${this.navigation ? x`
+        ${this.navigation ? b`
               <div part="navigation" class="carousel__navigation">
                 <button
                   part="navigation-button navigation-button--previous"
@@ -23715,11 +23637,11 @@ var SlCarousel = class extends ShoelaceElement {
                 </button>
               </div>
             ` : ""}
-        ${this.pagination ? x`
+        ${this.pagination ? b`
               <div part="pagination" role="tablist" class="carousel__pagination">
                 ${o$1(o(pagesCount), index => {
       const isActive = index === currentPage;
-      return x`
+      return b`
                     <button
                       part="pagination-item ${isActive ? "pagination-item--active" : ""}"
                       class="${e$3({
@@ -23781,11 +23703,11 @@ __decorateClass([n$6({
   reflect: true,
   attribute: "mouse-dragging"
 })], SlCarousel.prototype, "mouseDragging", 2);
-__decorateClass([e$7(".carousel__slides")], SlCarousel.prototype, "scrollContainer", 2);
-__decorateClass([e$7(".carousel__pagination")], SlCarousel.prototype, "paginationContainer", 2);
-__decorateClass([r$3()], SlCarousel.prototype, "activeSlide", 2);
-__decorateClass([r$3()], SlCarousel.prototype, "scrolling", 2);
-__decorateClass([r$3()], SlCarousel.prototype, "dragging", 2);
+__decorateClass([e$6(".carousel__slides")], SlCarousel.prototype, "scrollContainer", 2);
+__decorateClass([e$6(".carousel__pagination")], SlCarousel.prototype, "paginationContainer", 2);
+__decorateClass([r$4()], SlCarousel.prototype, "activeSlide", 2);
+__decorateClass([r$4()], SlCarousel.prototype, "scrolling", 2);
+__decorateClass([r$4()], SlCarousel.prototype, "dragging", 2);
 __decorateClass([t$2({
   passive: true
 })], SlCarousel.prototype, "handleScroll", 1);
@@ -23838,7 +23760,7 @@ var SlCarouselItem = class extends ShoelaceElement {
     super.connectedCallback();
   }
   render() {
-    return x` <slot></slot> `;
+    return b` <slot></slot> `;
   }
 };
 SlCarouselItem.styles = [component_styles_default, carousel_item_styles_default];
@@ -24381,9 +24303,9 @@ SlButton.dependencies = {
   "sl-icon": SlIcon,
   "sl-spinner": SlSpinner
 };
-__decorateClass([e$7(".button")], SlButton.prototype, "button", 2);
-__decorateClass([r$3()], SlButton.prototype, "hasFocus", 2);
-__decorateClass([r$3()], SlButton.prototype, "invalid", 2);
+__decorateClass([e$6(".button")], SlButton.prototype, "button", 2);
+__decorateClass([r$4()], SlButton.prototype, "hasFocus", 2);
+__decorateClass([r$4()], SlButton.prototype, "invalid", 2);
 __decorateClass([n$6()], SlButton.prototype, "title", 2);
 __decorateClass([n$6({
   reflect: true
@@ -26236,7 +26158,7 @@ var SlColorPicker = class extends ShoelaceElement {
     const gridHandleX = this.saturation;
     const gridHandleY = 100 - this.brightness;
     const swatches = Array.isArray(this.swatches) ? this.swatches : this.swatches.split(";").filter(color => color.trim() !== "");
-    const colorPicker = x`
+    const colorPicker = b`
       <div
         part="base"
         class=${e$3({
@@ -26249,7 +26171,7 @@ var SlColorPicker = class extends ShoelaceElement {
         aria-labelledby="label"
         tabindex=${this.inline ? "0" : "-1"}
       >
-        ${this.inline ? x`
+        ${this.inline ? b`
               <sl-visually-hidden id="label">
                 <slot name="label">${this.label}</slot>
               </sl-visually-hidden>
@@ -26307,7 +26229,7 @@ var SlColorPicker = class extends ShoelaceElement {
               ></span>
             </div>
 
-            ${this.opacity ? x`
+            ${this.opacity ? b`
                   <div
                     part="slider opacity-slider"
                     class="color-picker__alpha color-picker__slider color-picker__transparent-bg"
@@ -26377,7 +26299,7 @@ var SlColorPicker = class extends ShoelaceElement {
           ></sl-input>
 
           <sl-button-group>
-            ${!this.noFormatToggle ? x`
+            ${!this.noFormatToggle ? b`
                   <sl-button
                     part="format-button"
                     aria-label=${this.localize.term("toggleColorFormat")}
@@ -26395,7 +26317,7 @@ var SlColorPicker = class extends ShoelaceElement {
                     ${this.setLetterCase(this.format)}
                   </sl-button>
                 ` : ""}
-            ${hasEyeDropper ? x`
+            ${hasEyeDropper ? b`
                   <sl-button
                     part="eye-dropper-button"
                     exportparts="
@@ -26419,7 +26341,7 @@ var SlColorPicker = class extends ShoelaceElement {
           </sl-button-group>
         </div>
 
-        ${swatches.length > 0 ? x`
+        ${swatches.length > 0 ? b`
               <div part="swatches" class="color-picker__swatches">
                 ${swatches.map(swatch => {
       const parsedColor = this.parseColor(swatch);
@@ -26427,7 +26349,7 @@ var SlColorPicker = class extends ShoelaceElement {
         console.error(`Unable to parse swatch color: "${swatch}"`, this);
         return "";
       }
-      return x`
+      return b`
                     <div
                       part="swatch"
                       class="color-picker__swatch color-picker__transparent-bg"
@@ -26453,7 +26375,7 @@ var SlColorPicker = class extends ShoelaceElement {
     if (this.inline) {
       return colorPicker;
     }
-    return x`
+    return b`
       <sl-dropdown
         class="color-dropdown"
         aria-disabled=${this.disabled ? "true" : "false"}
@@ -26498,19 +26420,19 @@ SlColorPicker.dependencies = {
   "sl-input": SlInput,
   "sl-visually-hidden": SlVisuallyHidden
 };
-__decorateClass([e$7('[part~="base"]')], SlColorPicker.prototype, "base", 2);
-__decorateClass([e$7('[part~="input"]')], SlColorPicker.prototype, "input", 2);
-__decorateClass([e$7(".color-dropdown")], SlColorPicker.prototype, "dropdown", 2);
-__decorateClass([e$7('[part~="preview"]')], SlColorPicker.prototype, "previewButton", 2);
-__decorateClass([e$7('[part~="trigger"]')], SlColorPicker.prototype, "trigger", 2);
-__decorateClass([r$3()], SlColorPicker.prototype, "hasFocus", 2);
-__decorateClass([r$3()], SlColorPicker.prototype, "isDraggingGridHandle", 2);
-__decorateClass([r$3()], SlColorPicker.prototype, "isEmpty", 2);
-__decorateClass([r$3()], SlColorPicker.prototype, "inputValue", 2);
-__decorateClass([r$3()], SlColorPicker.prototype, "hue", 2);
-__decorateClass([r$3()], SlColorPicker.prototype, "saturation", 2);
-__decorateClass([r$3()], SlColorPicker.prototype, "brightness", 2);
-__decorateClass([r$3()], SlColorPicker.prototype, "alpha", 2);
+__decorateClass([e$6('[part~="base"]')], SlColorPicker.prototype, "base", 2);
+__decorateClass([e$6('[part~="input"]')], SlColorPicker.prototype, "input", 2);
+__decorateClass([e$6(".color-dropdown")], SlColorPicker.prototype, "dropdown", 2);
+__decorateClass([e$6('[part~="preview"]')], SlColorPicker.prototype, "previewButton", 2);
+__decorateClass([e$6('[part~="trigger"]')], SlColorPicker.prototype, "trigger", 2);
+__decorateClass([r$4()], SlColorPicker.prototype, "hasFocus", 2);
+__decorateClass([r$4()], SlColorPicker.prototype, "isDraggingGridHandle", 2);
+__decorateClass([r$4()], SlColorPicker.prototype, "isEmpty", 2);
+__decorateClass([r$4()], SlColorPicker.prototype, "inputValue", 2);
+__decorateClass([r$4()], SlColorPicker.prototype, "hue", 2);
+__decorateClass([r$4()], SlColorPicker.prototype, "saturation", 2);
+__decorateClass([r$4()], SlColorPicker.prototype, "brightness", 2);
+__decorateClass([r$4()], SlColorPicker.prototype, "alpha", 2);
 __decorateClass([n$6()], SlColorPicker.prototype, "value", 2);
 __decorateClass([defaultValue()], SlColorPicker.prototype, "defaultValue", 2);
 __decorateClass([n$6()], SlColorPicker.prototype, "label", 2);
@@ -26715,7 +26637,7 @@ var SlCopyButton = class extends ShoelaceElement {
   }
   render() {
     const copyLabel = this.copyLabel || this.localize.term("copy");
-    return x`
+    return b`
       <sl-tooltip
         class=${e$3({
       "copy-button": true,
@@ -26759,12 +26681,12 @@ SlCopyButton.dependencies = {
   "sl-icon": SlIcon,
   "sl-tooltip": SlTooltip
 };
-__decorateClass([e$7('slot[name="copy-icon"]')], SlCopyButton.prototype, "copyIcon", 2);
-__decorateClass([e$7('slot[name="success-icon"]')], SlCopyButton.prototype, "successIcon", 2);
-__decorateClass([e$7('slot[name="error-icon"]')], SlCopyButton.prototype, "errorIcon", 2);
-__decorateClass([e$7("sl-tooltip")], SlCopyButton.prototype, "tooltip", 2);
-__decorateClass([r$3()], SlCopyButton.prototype, "isCopying", 2);
-__decorateClass([r$3()], SlCopyButton.prototype, "status", 2);
+__decorateClass([e$6('slot[name="copy-icon"]')], SlCopyButton.prototype, "copyIcon", 2);
+__decorateClass([e$6('slot[name="success-icon"]')], SlCopyButton.prototype, "successIcon", 2);
+__decorateClass([e$6('slot[name="error-icon"]')], SlCopyButton.prototype, "errorIcon", 2);
+__decorateClass([e$6("sl-tooltip")], SlCopyButton.prototype, "tooltip", 2);
+__decorateClass([r$4()], SlCopyButton.prototype, "isCopying", 2);
+__decorateClass([r$4()], SlCopyButton.prototype, "status", 2);
 __decorateClass([n$6()], SlCopyButton.prototype, "value", 2);
 __decorateClass([n$6()], SlCopyButton.prototype, "from", 2);
 __decorateClass([n$6({
@@ -27035,7 +26957,7 @@ var SlDetails = class extends ShoelaceElement {
   }
   render() {
     const isRtl = this.localize.dir() === "rtl";
-    return x`
+    return b`
       <details
         part="base"
         class=${e$3({
@@ -27080,10 +27002,10 @@ SlDetails.styles = [component_styles_default, details_styles_default];
 SlDetails.dependencies = {
   "sl-icon": SlIcon
 };
-__decorateClass([e$7(".details")], SlDetails.prototype, "details", 2);
-__decorateClass([e$7(".details__header")], SlDetails.prototype, "header", 2);
-__decorateClass([e$7(".details__body")], SlDetails.prototype, "body", 2);
-__decorateClass([e$7(".details__expand-icon-slot")], SlDetails.prototype, "expandIconSlot", 2);
+__decorateClass([e$6(".details")], SlDetails.prototype, "details", 2);
+__decorateClass([e$6(".details__header")], SlDetails.prototype, "header", 2);
+__decorateClass([e$6(".details__body")], SlDetails.prototype, "body", 2);
+__decorateClass([e$6(".details__expand-icon-slot")], SlDetails.prototype, "expandIconSlot", 2);
 __decorateClass([n$6({
   type: Boolean,
   reflect: true
@@ -27405,7 +27327,7 @@ var SlDialog = class extends ShoelaceElement {
     return waitForEvent(this, "sl-after-hide");
   }
   render() {
-    return x`
+    return b`
       <div
         part="base"
         class=${e$3({
@@ -27426,7 +27348,7 @@ var SlDialog = class extends ShoelaceElement {
           aria-labelledby=${o$6(!this.noHeader ? "title" : void 0)}
           tabindex="-1"
         >
-          ${!this.noHeader ? x`
+          ${!this.noHeader ? b`
                 <header part="header" class="dialog__header">
                   <h2 part="title" class="dialog__title" id="title">
                     <slot name="label"> ${this.label.length > 0 ? this.label : String.fromCharCode(65279)} </slot>
@@ -27460,9 +27382,9 @@ SlDialog.styles = [component_styles_default, dialog_styles_default];
 SlDialog.dependencies = {
   "sl-icon-button": SlIconButton
 };
-__decorateClass([e$7(".dialog")], SlDialog.prototype, "dialog", 2);
-__decorateClass([e$7(".dialog__panel")], SlDialog.prototype, "panel", 2);
-__decorateClass([e$7(".dialog__overlay")], SlDialog.prototype, "overlay", 2);
+__decorateClass([e$6(".dialog")], SlDialog.prototype, "dialog", 2);
+__decorateClass([e$6(".dialog__panel")], SlDialog.prototype, "panel", 2);
+__decorateClass([e$6(".dialog__overlay")], SlDialog.prototype, "overlay", 2);
 __decorateClass([n$6({
   type: Boolean,
   reflect: true
@@ -27644,7 +27566,7 @@ var SlAnimatedImage = class extends ShoelaceElement {
     this.isLoaded = false;
   }
   render() {
-    return x`
+    return b`
       <div class="animated-image">
         <img
           class="animated-image__animated"
@@ -27657,7 +27579,7 @@ var SlAnimatedImage = class extends ShoelaceElement {
           @error=${this.handleError}
         />
 
-        ${this.isLoaded ? x`
+        ${this.isLoaded ? b`
               <img
                 class="animated-image__frozen"
                 src=${this.frozenFrame}
@@ -27679,9 +27601,9 @@ SlAnimatedImage.styles = [component_styles_default, animated_image_styles_defaul
 SlAnimatedImage.dependencies = {
   "sl-icon": SlIcon
 };
-__decorateClass([e$7(".animated-image__animated")], SlAnimatedImage.prototype, "animatedImage", 2);
-__decorateClass([r$3()], SlAnimatedImage.prototype, "frozenFrame", 2);
-__decorateClass([r$3()], SlAnimatedImage.prototype, "isLoaded", 2);
+__decorateClass([e$6(".animated-image__animated")], SlAnimatedImage.prototype, "animatedImage", 2);
+__decorateClass([r$4()], SlAnimatedImage.prototype, "frozenFrame", 2);
+__decorateClass([r$4()], SlAnimatedImage.prototype, "isLoaded", 2);
 __decorateClass([n$6()], SlAnimatedImage.prototype, "src", 2);
 __decorateClass([n$6()], SlAnimatedImage.prototype, "alt", 2);
 __decorateClass([n$6({
@@ -29400,11 +29322,11 @@ var SlAnimation = class extends ShoelaceElement {
     (_a = this.animation) == null ? void 0 : _a.finish();
   }
   render() {
-    return x` <slot @slotchange=${this.handleSlotChange}></slot> `;
+    return b` <slot @slotchange=${this.handleSlotChange}></slot> `;
   }
 };
 SlAnimation.styles = [component_styles_default, animation_styles_default];
-__decorateClass([r$2("slot")], SlAnimation.prototype, "defaultSlot", 2);
+__decorateClass([r$3("slot")], SlAnimation.prototype, "defaultSlot", 2);
 __decorateClass([n$6()], SlAnimation.prototype, "name", 2);
 __decorateClass([n$6({
   type: Boolean,
@@ -29539,7 +29461,7 @@ var SlAvatar = class extends ShoelaceElement {
     this.emit("sl-error");
   }
   render() {
-    const avatarWithImage = x`
+    const avatarWithImage = b`
       <img
         part="image"
         class="avatar__image"
@@ -29549,11 +29471,11 @@ var SlAvatar = class extends ShoelaceElement {
         @error="${this.handleImageLoadError}"
       />
     `;
-    let avatarWithoutImage = x``;
+    let avatarWithoutImage = b``;
     if (this.initials) {
-      avatarWithoutImage = x`<div part="initials" class="avatar__initials">${this.initials}</div>`;
+      avatarWithoutImage = b`<div part="initials" class="avatar__initials">${this.initials}</div>`;
     } else {
-      avatarWithoutImage = x`
+      avatarWithoutImage = b`
         <div part="icon" class="avatar__icon" aria-hidden="true">
           <slot name="icon">
             <sl-icon name="person-fill" library="system"></sl-icon>
@@ -29561,7 +29483,7 @@ var SlAvatar = class extends ShoelaceElement {
         </div>
       `;
     }
-    return x`
+    return b`
       <div
         part="base"
         class=${e$3({
@@ -29582,7 +29504,7 @@ SlAvatar.styles = [component_styles_default, avatar_styles_default];
 SlAvatar.dependencies = {
   "sl-icon": SlIcon
 };
-__decorateClass([r$3()], SlAvatar.prototype, "hasError", 2);
+__decorateClass([r$4()], SlAvatar.prototype, "hasError", 2);
 __decorateClass([n$6()], SlAvatar.prototype, "image", 2);
 __decorateClass([n$6()], SlAvatar.prototype, "label", 2);
 __decorateClass([n$6()], SlAvatar.prototype, "initials", 2);
@@ -29654,7 +29576,7 @@ var SlBreadcrumb = class extends ShoelaceElement {
       this.separatorDir = this.localize.dir();
       this.updateComplete.then(() => this.handleSlotChange());
     }
-    return x`
+    return b`
       <nav part="base" class="breadcrumb" aria-label=${this.label}>
         <slot @slotchange=${this.handleSlotChange}></slot>
       </nav>
@@ -29671,8 +29593,8 @@ SlBreadcrumb.styles = [component_styles_default, breadcrumb_styles_default];
 SlBreadcrumb.dependencies = {
   "sl-icon": SlIcon
 };
-__decorateClass([e$7("slot")], SlBreadcrumb.prototype, "defaultSlot", 2);
-__decorateClass([e$7('slot[name="separator"]')], SlBreadcrumb.prototype, "separatorSlot", 2);
+__decorateClass([e$6("slot")], SlBreadcrumb.prototype, "defaultSlot", 2);
+__decorateClass([e$6('slot[name="separator"]')], SlBreadcrumb.prototype, "separatorSlot", 2);
 __decorateClass([n$6()], SlBreadcrumb.prototype, "label", 2);
 
 var tagName$5 = "sl-breadcrumb";
@@ -29813,7 +29735,7 @@ var SlBreadcrumbItem = class extends ShoelaceElement {
     this.setRenderType();
   }
   render() {
-    return x`
+    return b`
       <div
         part="base"
         class=${e$3({
@@ -29826,7 +29748,7 @@ var SlBreadcrumbItem = class extends ShoelaceElement {
           <slot name="prefix"></slot>
         </span>
 
-        ${this.renderType === "link" ? x`
+        ${this.renderType === "link" ? b`
               <a
                 part="label"
                 class="breadcrumb-item__label breadcrumb-item__label--link"
@@ -29837,12 +29759,12 @@ var SlBreadcrumbItem = class extends ShoelaceElement {
                 <slot @slotchange=${this.handleSlotChange}></slot>
               </a>
             ` : ""}
-        ${this.renderType === "button" ? x`
+        ${this.renderType === "button" ? b`
               <button part="label" type="button" class="breadcrumb-item__label breadcrumb-item__label--button">
                 <slot @slotchange=${this.handleSlotChange}></slot>
               </button>
             ` : ""}
-        ${this.renderType === "dropdown" ? x`
+        ${this.renderType === "dropdown" ? b`
               <div part="label" class="breadcrumb-item__label breadcrumb-item__label--drop-down">
                 <slot @slotchange=${this.handleSlotChange}></slot>
               </div>
@@ -29860,8 +29782,8 @@ var SlBreadcrumbItem = class extends ShoelaceElement {
   }
 };
 SlBreadcrumbItem.styles = [component_styles_default, breadcrumb_item_styles_default];
-__decorateClass([e$7("slot:not([name])")], SlBreadcrumbItem.prototype, "defaultSlot", 2);
-__decorateClass([r$3()], SlBreadcrumbItem.prototype, "renderType", 2);
+__decorateClass([e$6("slot:not([name])")], SlBreadcrumbItem.prototype, "defaultSlot", 2);
+__decorateClass([r$4()], SlBreadcrumbItem.prototype, "renderType", 2);
 __decorateClass([n$6()], SlBreadcrumbItem.prototype, "href", 2);
 __decorateClass([n$6()], SlBreadcrumbItem.prototype, "target", 2);
 __decorateClass([n$6()], SlBreadcrumbItem.prototype, "rel", 2);
@@ -29979,7 +29901,7 @@ var SlBadge = class extends ShoelaceElement {
     this.pulse = false;
   }
   render() {
-    return x`
+    return b`
       <span
         part="base"
         class=${e$3({
@@ -30096,7 +30018,7 @@ var SlCard = class extends ShoelaceElement {
     this.hasSlotController = new HasSlotController(this, "footer", "header", "image");
   }
   render() {
-    return x`
+    return b`
       <div
         part="base"
         class=${e$3({
@@ -30419,7 +30341,7 @@ var _SlAlert = class _SlAlert extends ShoelaceElement {
     });
   }
   render() {
-    return x`
+    return b`
       <div
         part="base"
         class=${e$3({
@@ -30447,7 +30369,7 @@ var _SlAlert = class _SlAlert extends ShoelaceElement {
           <slot></slot>
         </div>
 
-        ${this.closable ? x`
+        ${this.closable ? b`
               <sl-icon-button
                 part="close-button"
                 exportparts="base:close-button__base"
@@ -30461,7 +30383,7 @@ var _SlAlert = class _SlAlert extends ShoelaceElement {
 
         <div role="timer" class="alert__timer">${this.remainingTime}</div>
 
-        ${this.countdown ? x`
+        ${this.countdown ? b`
               <div
                 class=${e$3({
       alert__countdown: true,
@@ -30479,8 +30401,8 @@ _SlAlert.styles = [component_styles_default, alert_styles_default];
 _SlAlert.dependencies = {
   "sl-icon-button": SlIconButton
 };
-__decorateClass([e$7('[part~="base"]')], _SlAlert.prototype, "base", 2);
-__decorateClass([e$7(".alert__countdown-elapsed")], _SlAlert.prototype, "countdownElement", 2);
+__decorateClass([e$6('[part~="base"]')], _SlAlert.prototype, "base", 2);
+__decorateClass([e$6(".alert__countdown-elapsed")], _SlAlert.prototype, "countdownElement", 2);
 __decorateClass([n$6({
   type: Boolean,
   reflect: true
@@ -30499,7 +30421,7 @@ __decorateClass([n$6({
   type: String,
   reflect: true
 })], _SlAlert.prototype, "countdown", 2);
-__decorateClass([r$3()], _SlAlert.prototype, "remainingTime", 2);
+__decorateClass([r$4()], _SlAlert.prototype, "remainingTime", 2);
 __decorateClass([watch("open", {
   waitUntilFirstUpdate: true
 })], _SlAlert.prototype, "handleOpenChange", 1);
@@ -30647,7 +30569,7 @@ var hasRequiredScheduler_production;
 function requireScheduler_production () {
 	if (hasRequiredScheduler_production) return scheduler_production;
 	hasRequiredScheduler_production = 1;
-	(function (exports) {
+	(function (exports$1) {
 
 		function push(heap, node) {
 		  var index = heap.length;
@@ -30681,16 +30603,16 @@ function requireScheduler_production () {
 		  var diff = a.sortIndex - b.sortIndex;
 		  return 0 !== diff ? diff : a.id - b.id;
 		}
-		exports.unstable_now = void 0;
+		exports$1.unstable_now = void 0;
 		if ("object" === typeof performance && "function" === typeof performance.now) {
 		  var localPerformance = performance;
-		  exports.unstable_now = function () {
+		  exports$1.unstable_now = function () {
 		    return localPerformance.now();
 		  };
 		} else {
 		  var localDate = Date,
 		    initialTime = localDate.now();
-		  exports.unstable_now = function () {
+		  exports$1.unstable_now = function () {
 		    return localDate.now() - initialTime;
 		  };
 		}
@@ -30725,12 +30647,12 @@ function requireScheduler_production () {
 		  frameInterval = 5,
 		  startTime = -1;
 		function shouldYieldToHost() {
-		  return needsPaint ? true : exports.unstable_now() - startTime < frameInterval ? false : true;
+		  return needsPaint ? true : exports$1.unstable_now() - startTime < frameInterval ? false : true;
 		}
 		function performWorkUntilDeadline() {
 		  needsPaint = false;
 		  if (isMessageLoopRunning) {
-		    var currentTime = exports.unstable_now();
+		    var currentTime = exports$1.unstable_now();
 		    startTime = currentTime;
 		    var hasMoreWork = true;
 		    try {
@@ -30748,7 +30670,7 @@ function requireScheduler_production () {
 		                currentTask.callback = null;
 		                currentPriorityLevel = currentTask.priorityLevel;
 		                var continuationCallback = callback(currentTask.expirationTime <= currentTime);
-		                currentTime = exports.unstable_now();
+		                currentTime = exports$1.unstable_now();
 		                if ("function" === typeof continuationCallback) {
 		                  currentTask.callback = continuationCallback;
 		                  advanceTimers(currentTime);
@@ -30792,25 +30714,25 @@ function requireScheduler_production () {
 		};
 		function requestHostTimeout(callback, ms) {
 		  taskTimeoutID = localSetTimeout(function () {
-		    callback(exports.unstable_now());
+		    callback(exports$1.unstable_now());
 		  }, ms);
 		}
-		exports.unstable_IdlePriority = 5;
-		exports.unstable_ImmediatePriority = 1;
-		exports.unstable_LowPriority = 4;
-		exports.unstable_NormalPriority = 3;
-		exports.unstable_Profiling = null;
-		exports.unstable_UserBlockingPriority = 2;
-		exports.unstable_cancelCallback = function (task) {
+		exports$1.unstable_IdlePriority = 5;
+		exports$1.unstable_ImmediatePriority = 1;
+		exports$1.unstable_LowPriority = 4;
+		exports$1.unstable_NormalPriority = 3;
+		exports$1.unstable_Profiling = null;
+		exports$1.unstable_UserBlockingPriority = 2;
+		exports$1.unstable_cancelCallback = function (task) {
 		  task.callback = null;
 		};
-		exports.unstable_forceFrameRate = function (fps) {
+		exports$1.unstable_forceFrameRate = function (fps) {
 		  0 > fps || 125 < fps ? console.error("forceFrameRate takes a positive int between 0 and 125, forcing frame rates higher than 125 fps is not supported") : frameInterval = 0 < fps ? Math.floor(1e3 / fps) : 5;
 		};
-		exports.unstable_getCurrentPriorityLevel = function () {
+		exports$1.unstable_getCurrentPriorityLevel = function () {
 		  return currentPriorityLevel;
 		};
-		exports.unstable_next = function (eventHandler) {
+		exports$1.unstable_next = function (eventHandler) {
 		  switch (currentPriorityLevel) {
 		    case 1:
 		    case 2:
@@ -30828,10 +30750,10 @@ function requireScheduler_production () {
 		    currentPriorityLevel = previousPriorityLevel;
 		  }
 		};
-		exports.unstable_requestPaint = function () {
+		exports$1.unstable_requestPaint = function () {
 		  needsPaint = true;
 		};
-		exports.unstable_runWithPriority = function (priorityLevel, eventHandler) {
+		exports$1.unstable_runWithPriority = function (priorityLevel, eventHandler) {
 		  switch (priorityLevel) {
 		    case 1:
 		    case 2:
@@ -30850,8 +30772,8 @@ function requireScheduler_production () {
 		    currentPriorityLevel = previousPriorityLevel;
 		  }
 		};
-		exports.unstable_scheduleCallback = function (priorityLevel, callback, options) {
-		  var currentTime = exports.unstable_now();
+		exports$1.unstable_scheduleCallback = function (priorityLevel, callback, options) {
+		  var currentTime = exports$1.unstable_now();
 		  "object" === typeof options && null !== options ? (options = options.delay, options = "number" === typeof options && 0 < options ? currentTime + options : currentTime) : options = currentTime;
 		  switch (priorityLevel) {
 		    case 1:
@@ -30881,8 +30803,8 @@ function requireScheduler_production () {
 		  options > currentTime ? (priorityLevel.sortIndex = options, push(timerQueue, priorityLevel), null === peek(taskQueue) && priorityLevel === peek(timerQueue) && (isHostTimeoutScheduled ? (localClearTimeout(taskTimeoutID), taskTimeoutID = -1) : isHostTimeoutScheduled = true, requestHostTimeout(handleTimeout, options - currentTime))) : (priorityLevel.sortIndex = timeout, push(taskQueue, priorityLevel), isHostCallbackScheduled || isPerformingWork || (isHostCallbackScheduled = true, isMessageLoopRunning || (isMessageLoopRunning = true, schedulePerformWorkUntilDeadline())));
 		  return priorityLevel;
 		};
-		exports.unstable_shouldYield = shouldYieldToHost;
-		exports.unstable_wrapCallback = function (callback) {
+		exports$1.unstable_shouldYield = shouldYieldToHost;
+		exports$1.unstable_wrapCallback = function (callback) {
 		  var parentPriorityLevel = currentPriorityLevel;
 		  return function () {
 		    var previousPriorityLevel = currentPriorityLevel;


### PR DESCRIPTION
Bumps direct dependencies and adds npm overrides to fix 16 open Dependabot alerts in `ui/extensions/Third-party Detections`.

**Direct dependency bumps:**
- `rollup`: 4.41.1 -> 4.59.0 (arbitrary file write via path traversal)
- `react-router-dom`: 7.6.1 -> 7.13.1 (fixes XSS, CSRF, and open redirect vulnerabilities in react-router)

**Transitive dependency overrides:**
- `svgo` >= 2.8.1 (DoS through entity expansion)
- `minimatch` >= 3.1.4 (ReDoS via multiple patterns)
- `glob` >= 10.5.0 (command injection via CLI)
- `lodash` >= 4.17.23 (prototype pollution)
- `tmp` >= 0.2.4 (arbitrary file write via symlink)
- `brace-expansion` >= 1.1.12 (ReDoS)

Rebuilt `package-lock.json` and `src/dist/app.js` with `npm install` and `npm run build`. `npm audit` reports 0 vulnerabilities.