### PR TITLE
Restrict dependabot version updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "14:00"
+      timezone: "UTC"
+    ignore:
+      - dependency-name: "actions/checkout"
+        versions: [">=6.0.3"]
+      - dependency-name: "actions/setup-node"
+        versions: [">=6.3.0"]


### PR DESCRIPTION
Add ignore rules to prevent dependabot from bumping actions beyond versions allowed by the CrowdStrike org policy. Matches the pattern used in foundry-sample repos (e.g., foundry-sample-rapid-response).